### PR TITLE
Fix build on OpenMandriva (and probably other distros)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "SunPro")
 endif()
 
 find_package(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIRS})
+include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIR})
 if(WIN32)
     # -lmingw32: gcc adds it automatically.
     # -mwindows: doesn't make sense.
@@ -166,7 +166,7 @@ if(SDLSOUND_BUILD_SHARED)
         # avoid DLL having "lib" prefix
         SET(CMAKE_SHARED_LIBRARY_PREFIX "")
     endif()
-    target_link_libraries(SDL2_sound ${SDL2_LIBRARIES} ${OPTIONAL_LIBRARY_LIBS} ${OTHER_LDFLAGS})
+    target_link_libraries(SDL2_sound ${SDL2_LIBRARIES} ${SDL2_LIBRARY} ${OPTIONAL_LIBRARY_LIBS} ${OTHER_LDFLAGS})
     set(SDLSOUND_LIB_TARGET SDL2_sound)
     set(SDLSOUND_INSTALL_TARGETS ${SDLSOUND_INSTALL_TARGETS} ";SDL2_sound")
 endif()


### PR DESCRIPTION
Building current SDL2_sound on OpenMandriva results in a build failure
(#include "SDL.h" fails); if fixed, it results in a linking failure
(unresolved symbols for everything that's supposed to come from SDL).

Looking at it, the problem is that SDL_sound CMakeLists.txt assumes
"find_package(SDL2 REQUIRED)" sets SDL2_INCLUDE_DIRS and
SDL2_LIBRARIES -- when in fact it (or at least the version we have)
sets SDL2_INCLUDE_DIR and SDL2_LIBRARY.

Looks like there are 2 different not fully compatible versions of
FindSDL2.cmake around (ours comes from SDL2 2.0.14).

This patch adds SDL2_INCLUDE_DIR and SDL2_LIBRARY -- works here, and
should be harmless even with the other FindSDL2.cmake (given they'll
just expand to nothing, as SDL2_INCLUDE_DIRS and SDL2_LIBRARIES does
here).

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>