### PR TITLE
CMake: fix coreaudio in MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ sdlsound_decoder_option(MP3 "MPEG-1 Layers I-III" ".MP3, .MP2, .MP1" TRUE)
 sdlsound_decoder_option(MIDI "Midi" ".MID" FALSE)
 
 if(APPLE)
-    sdlsound_decoder_option(COREAUDIO "CoreAudio" "various audio formats")
+    sdlsound_decoder_option(COREAUDIO "CoreAudio" "various audio formats" TRUE)
     if(SDLSOUND_DECODER_COREAUDIO)
         set(OPTIONAL_LIBRARY_LIBS ${OPTIONAL_LIBRARY_LIBS} "-framework AudioToolbox")
     endif()


### PR DESCRIPTION
Found this error:

```
CMakeLists.txt:66 (sdlsound_decoder_option):
  sdlsound_decoder_option Macro invoked with incorrect arguments for macro
  named: sdlsound_decoder_option
```

Don't know if the default should be true or false, but guessing true.

Regression from commit: https://github.com/icculus/SDL_sound/commit/20ed6eef8e8affd63c96e0ea124a7fc7a36baa89