### PR TITLE
CI: explicitly enable midi decoder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Get SDL_sound sources
       uses: actions/checkout@v2
     - name: Configure CMake
-      run: cmake -B build ${{ matrix.platform.flags }}
+      run: cmake -B build -DSDLSOUND_DECODER_MIDI=ON ${{ matrix.platform.flags }}
     - name: Build
       run: cmake --build build/


### PR DESCRIPTION
after https://github.com/icculus/SDL_sound/commit/20ed6eef8e8affd63c96e0ea124a7fc7a36baa89 the MIDI decode is disabled, I think it's still useful to build it in the CI to check the sources though.