### PR TITLE
timidity: Use the format information from sample->desired

### DIFF
--- a/src/SDL_sound_midi.c
+++ b/src/SDL_sound_midi.c
@@ -69,10 +69,10 @@ static int MIDI_open(Sound_Sample *sample, const char *ext)
     SDL_AudioSpec spec;
     MidiSong *song;
 
-    spec.channels = 2;
-    spec.format = AUDIO_S16SYS;
-    spec.freq = 44100;
-    spec.samples = 4096;
+    spec.channels = (sample->desired.channels == 1) ? 1 : 2;
+    spec.format = (sample->desired.format == 0) ? AUDIO_S16SYS : sample->desired.format;
+    spec.freq = (sample->desired.rate == 0) ? 44100 : sample->desired.rate;
+    spec.samples = sample->buffer_size / (SDL_AUDIO_BITSIZE(spec.format) / 8) / spec.channels;
     
     song = Timidity_LoadSong(rw, &spec);
     BAIL_IF_MACRO(song == NULL, "MIDI: Not a MIDI file.", 0);
@@ -84,9 +84,9 @@ static int MIDI_open(Sound_Sample *sample, const char *ext)
     internal->decoder_private = (void *) song;
     internal->total_time = Timidity_GetSongLength(song);
 
-    sample->actual.channels = 2;
-    sample->actual.rate = 44100;
-    sample->actual.format = AUDIO_S16SYS;
+    sample->actual.channels = spec.channels;
+    sample->actual.rate = spec.freq;
+    sample->actual.format = spec.format;
     sample->flags = SOUND_SAMPLEFLAG_CANSEEK;
     
     return(1); /* we'll handle this data. */

--- a/src/timidity/output.c
+++ b/src/timidity/output.c
@@ -106,6 +106,15 @@ void timi_s32tof32(void *dp, Sint32 *lp, Sint32 c)
     }
 }
 
+void timi_s32tof32x(void* dp, Sint32* lp, Sint32 c)
+{
+    float* sp = (float*)(dp);
+    while (c--)
+    {
+        *sp++ = SDL_SwapFloat((float)(*lp++) / 2147483647.0f);
+    }
+}
+
 void timi_s32tos32(void *dp, Sint32 *lp, Sint32 c)
 {
   Sint32 *sp=(Sint32 *)(dp);

--- a/src/timidity/output.h
+++ b/src/timidity/output.h
@@ -38,6 +38,7 @@ extern void timi_s32tof32(void *dp, Sint32 *lp, Sint32 c);
 extern void timi_s32tos32(void *dp, Sint32 *lp, Sint32 c);
 
 /* byte-exchanged 32-bit */
+extern void timi_s32tof32x(void* dp, Sint32* lp, Sint32 c);
 extern void timi_s32tos32x(void *dp, Sint32 *lp, Sint32 c);
 
 /* little-endian and big-endian specific */
@@ -48,6 +49,8 @@ extern void timi_s32tos32x(void *dp, Sint32 *lp, Sint32 c);
 #define timi_s32tos16b timi_s32tos16x
 #define timi_s32tos32l timi_s32tos32
 #define timi_s32tos32b timi_s32tos32x
+#define timi_s32tof32l timi_s32tof32
+#define timi_s32tof32b timi_s32tof32x
 #else
 #define timi_s32tou16l timi_s32tou16x
 #define timi_s32tou16b timi_s32tou16
@@ -55,6 +58,8 @@ extern void timi_s32tos32x(void *dp, Sint32 *lp, Sint32 c);
 #define timi_s32tos16b timi_s32tos16
 #define timi_s32tos32l timi_s32tos32x
 #define timi_s32tos32b timi_s32tos32
+#define timi_s32tof32l timi_s32tof32x
+#define timi_s32tof32b timi_s32tof32
 #endif
 
 #endif /* TIMIDITY_OUTPUT_H */

--- a/src/timidity/timidity.c
+++ b/src/timidity/timidity.c
@@ -585,8 +585,11 @@ static void do_song_load(SDL_RWops *rw, SDL_AudioSpec *audio, MidiSong **out)
   case AUDIO_S32MSB:
     song->write = timi_s32tos32b;
     break;
-  case AUDIO_F32SYS:
-    song->write = timi_s32tof32;
+  case AUDIO_F32LSB:
+    song->write = timi_s32tof32l;
+    break;
+  case AUDIO_F32MSB:
+    song->write = timi_s32tof32b;
     break;
   default:
     SDL_SetError("Unsupported audio format");


### PR DESCRIPTION
This works with all audio formats, however using `AUDIO_S32*` or `AUDIO_F32*` results in quieter audio compared to other formats. Some additional changes have also been copied over from SDL_mixer's version of TiMidity.