### PR TITLE
Remove unused math functions in dr_mp3.h

### DIFF
--- a/src/SDL_sound_flac.c
+++ b/src/SDL_sound_flac.c
@@ -35,12 +35,6 @@
 #define DRFLAC_FREE(p) SDL_free((p))
 #define DRFLAC_COPY_MEMORY(dst, src, sz) SDL_memcpy((dst), (src), (sz))
 #define DRFLAC_ZERO_MEMORY(p, sz) SDL_memset((p), 0, (sz))
-#ifndef __WATCOMC__ /* #@!.!.. */
-#if SDL_VERSION_ATLEAST(2, 0, 9)
-#define exp SDL_exp
-#endif
-#define floor SDL_floor
-#endif
 
 #include "dr_flac.h"
 

--- a/src/SDL_sound_mp3.c
+++ b/src/SDL_sound_mp3.c
@@ -29,12 +29,6 @@
 #define DRMP3_COPY_MEMORY(dst, src, sz) SDL_memcpy((dst), (src), (sz))
 #define DRMP3_MOVE_MEMORY(dst, src, sz) SDL_memmove((dst), (src), (sz))
 #define DRMP3_ZERO_MEMORY(p, sz) SDL_memset((p), 0, (sz))
-#ifndef __WATCOMC__ /* #@!.!.. */
-#if SDL_VERSION_ATLEAST(2, 0, 9)
-#define exp SDL_exp
-#endif
-#define floor SDL_floor
-#endif
 
 #include "dr_mp3.h"
 

--- a/src/dr_mp3.h
+++ b/src/dr_mp3.h
@@ -2406,8 +2406,6 @@ DRMP3_API void drmp3dec_f32_to_s16(const float *in, drmp3_int16 *out, size_t num
  Main Public API
 
  ************************************************************************************************************************************************************/
-#include <math.h>   /* For sin() and exp(). */
-
 #if defined(SIZE_MAX)
     #define DRMP3_SIZE_MAX  SIZE_MAX
 #else
@@ -2469,24 +2467,6 @@ static DRMP3_INLINE drmp3_uint32 drmp3_gcf_u32(drmp3_uint32 a, drmp3_uint32 b)
     }
 
     return a;
-}
-
-
-static DRMP3_INLINE double drmp3_sin(double x)
-{
-    /* TODO: Implement custom sin(x). */
-    return sin(x);
-}
-
-static DRMP3_INLINE double drmp3_exp(double x)
-{
-    /* TODO: Implement custom exp(x). */
-    return exp(x);
-}
-
-static DRMP3_INLINE double drmp3_cos(double x)
-{
-    return drmp3_sin((DRMP3_PI_D*0.5) - x);
 }
 
 


### PR DESCRIPTION
This fixes a build error with MSVC 2010 caused by defining `floor` before `math.h` is first included.

See also mackron/dr_libs#228.