### PR TITLE
Build libmodplug code as C++ code with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ if(SDLSOUND_DECODER_MODPLUG)
         src/libmodplug/sndfile.c
         src/libmodplug/sndmix.c
     )
+    if(MSVC)
+        set_source_files_properties(${LIBMODPLUG_SRCS} PROPERTIES LANGUAGE CXX)
+    endif()
 endif()
 
 # Almost everything is "compiled" here, but things that don't apply to the

--- a/src/SDL_sound_internal.h
+++ b/src/SDL_sound_internal.h
@@ -272,6 +272,10 @@ typedef struct __SOUND_SAMPLEINTERNAL__
 #define ERR_PREV_EOF             "Previous decoding already triggered EOF"
 #define ERR_CANNOT_SEEK          "Sample is not seekable"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Call this to set the message returned by Sound_GetError().
  *  Please only use the ERR_* constants above, or add new constants to the
@@ -304,6 +308,10 @@ extern char *SDL_strtokr(char *s1, const char *s2, char **saveptr);
 #define SDL_srand __Sound_srand
 extern int SDL_rand(void);
 extern void SDL_srand(unsigned int seed);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* defined _INCLUDE_SDL_SOUND_INTERNAL_H_ */
 


### PR DESCRIPTION
This allows libmodplug to be built with MSVC 2010, which has limited C99 support.