### PR TITLE
timidity: Sync with SDL_mixer

### DIFF
--- a/src/timidity/common.c
+++ b/src/timidity/common.c
@@ -14,7 +14,7 @@
 #include "options.h"
 #include "common.h"
 
-#if defined(_WIN32)||defined(__OS2__)
+#if defined(__WIN32__) || defined(__OS2__)
 #define CHAR_DIRSEP '\\'
 #define is_dirsep(c) ((c) == '/' || (c) == '\\')
 #define is_abspath(p) ((p)[0] == '/' || (p)[0] == '\\' || ((p)[0] && (p)[1] == ':'))

--- a/src/timidity/instrum.c
+++ b/src/timidity/instrum.c
@@ -41,7 +41,7 @@ static void free_bank(MidiSong *song, int dr, int b)
 {
   int i;
   ToneBank *bank=((dr) ? song->drumset[b] : song->tonebank[b]);
-  for (i=0; i<128; i++)
+  for (i=0; i<MAXBANK; i++)
     if (bank->instrument[i])
       {
 	if (bank->instrument[i] != MAGIC_LOAD_INSTRUMENT)
@@ -513,7 +513,7 @@ static int fill_bank(MidiSong *song, int dr, int b)
 	   (dr) ? "drumset" : "tone bank", b));
       return 0;
     }
-  for (i=0; i<128; i++)
+  for (i=0; i<MAXBANK; i++)
     {
       if (bank->instrument[i]==MAGIC_LOAD_INSTRUMENT)
 	{
@@ -574,7 +574,7 @@ static int fill_bank(MidiSong *song, int dr, int b)
 
 int load_missing_instruments(MidiSong *song)
 {
-  int i=128,errors=0;
+  int i=MAXBANK,errors=0;
   while (i--)
     {
       if (song->tonebank[i])
@@ -587,7 +587,7 @@ int load_missing_instruments(MidiSong *song)
 
 void free_instruments(MidiSong *song)
 {
-  int i=128;
+  int i=MAXBANK;
   while(i--)
     {
       if (song->tonebank[i])

--- a/src/timidity/options.h
+++ b/src/timidity/options.h
@@ -28,7 +28,8 @@
 #define DEFAULT_AMPLIFICATION 	70
 
 /* Default polyphony */
-#define DEFAULT_VOICES	32
+/* #define DEFAULT_VOICES	32 */
+#define DEFAULT_VOICES	256
 
 /* 1000 here will give a control ratio of 22:1 with 22 kHz output.
    Higher CONTROLS_PER_SECOND values allow more accurate rendering

--- a/src/timidity/playmidi.c
+++ b/src/timidity/playmidi.c
@@ -45,7 +45,7 @@ static void reset_controllers(MidiSong *song, int c)
 static void reset_midi(MidiSong *song)
 {
   int i;
-  for (i=0; i<16; i++)
+  for (i=0; i<MAXCHAN; i++)
     {
       reset_controllers(song, i);
       /* The rest of these are unaffected by the Reset All Controllers event */

--- a/src/timidity/readmidi.c
+++ b/src/timidity/readmidi.c
@@ -9,6 +9,7 @@
 #define __SDL_SOUND_INTERNAL__
 #include "SDL_sound_internal.h"
 
+#include "options.h"
 #include "timidity.h"
 #include "common.h"
 #include "instrum.h"
@@ -359,10 +360,10 @@ static MidiEvent *groom_list(MidiSong *song, Sint32 divisions,Sint32 *eventsp,
   Sint32 i, our_event_count, tempo, skip_this_event, new_value;
   Sint32 sample_cum, samples_to_do, at, st, dt, counting_time;
 
-  int current_bank[16], current_set[16], current_program[16];
+  int current_bank[MAXCHAN], current_set[MAXCHAN], current_program[MAXCHAN];
   /* Or should each bank have its own current program? */
 
-  for (i=0; i<16; i++)
+  for (i=0; i<MAXCHAN; i++)
     {
       current_bank[i]=0;
       current_set[i]=0;
@@ -393,7 +394,7 @@ static MidiEvent *groom_list(MidiSong *song, Sint32 divisions,Sint32 *eventsp,
 	{
 	  skip_this_event=1;
 	}
-      else if (meep->event.channel >= 16)
+      else if (meep->event.channel >= MAXCHAN)
         skip_this_event=1;
       else switch (meep->event.type)
 	{

--- a/src/timidity/timidity.c
+++ b/src/timidity/timidity.c
@@ -20,7 +20,7 @@
 
 #include "tables.h"
 
-static ToneBank *master_tonebank[128], *master_drumset[128];
+static ToneBank *master_tonebank[MAXBANK], *master_drumset[MAXBANK];
 
 static char def_instr_name[256] = "";
 
@@ -278,10 +278,10 @@ static int read_config_file(const char *name, int rcf_count)
 	goto fail;
       }
       i=SDL_atoi(w[1]);
-      if (i<0 || i>127)
+      if (i<0 || i>(MAXBANK-1))
       {
-	SNDDBG(("%s: line %d: Drum set must be between 0 and 127\n",
-		name, line));
+	SNDDBG(("%s: line %d: Drum set must be between 0 and %d\n",
+		name, line, MAXBANK-1));
 	goto fail;
       }
       if (!master_drumset[i])
@@ -301,10 +301,10 @@ static int read_config_file(const char *name, int rcf_count)
 	goto fail;
       }
       i=SDL_atoi(w[1]);
-      if (i<0 || i>127)
+      if (i<0 || i>(MAXBANK-1))
       {
-	SNDDBG(("%s: line %d: Tone bank must be between 0 and 127\n",
-		name, line));
+	SNDDBG(("%s: line %d: Tone bank must be between 0 and %d\n",
+		name, line, MAXBANK-1));
 	goto fail;
       }
       if (!master_tonebank[i])
@@ -526,7 +526,7 @@ static void do_song_load(SDL_RWops *rw, SDL_AudioSpec *audio, MidiSong **out)
   if (song == NULL)
       return;
 
-  for (i = 0; i < 128; i++)
+  for (i = 0; i < MAXBANK; i++)
   {
     if (master_tonebank[i]) {
       song->tonebank[i] = SDL_calloc(1, sizeof(ToneBank));
@@ -661,7 +661,7 @@ void Timidity_Exit(void)
 {
   int i, j;
 
-  for (i = 0; i < 128; i++) {
+  for (i = 0; i < MAXBANK; i++) {
     if (master_tonebank[i]) {
       ToneBankElement *e = master_tonebank[i]->tone;
       if (e != NULL) {

--- a/src/timidity/timidity.h
+++ b/src/timidity/timidity.h
@@ -19,7 +19,11 @@ typedef Sint32 final_volume_t;
 #define VIBRATO_SAMPLE_INCREMENTS 32
 
 /* Maximum polyphony. */
-#define MAX_VOICES	48
+/* #define MAX_VOICES	48 */
+#define MAX_VOICES	256
+#define MAXCHAN	16
+/* #define MAXCHAN	64 */
+#define MAXBANK	128
 
 typedef struct {
   Sint32
@@ -109,8 +113,8 @@ typedef struct {
     Sint32 encoding;
     float master_volume;
     Sint32 amplification;
-    ToneBank *tonebank[128];
-    ToneBank *drumset[128];
+    ToneBank *tonebank[MAXBANK];
+    ToneBank *drumset[MAXBANK];
     Instrument *default_instrument;
     int default_program;
     void (*write)(void *dp, Sint32 *lp, Sint32 c);
@@ -123,7 +127,7 @@ typedef struct {
     /* samples per MIDI delta-t */
     Sint32 sample_increment;
     Sint32 sample_correction;
-    Channel channel[16];
+    Channel channel[MAXCHAN];
     Voice voice[MAX_VOICES];
     int voices;
     Sint32 drumchannels;


### PR DESCRIPTION
This is split out from PR #47.

It was mentioned there that the values of `DEFAULT_VOICES` and `MAX_VOICES` are potentially higher than they need to be. Should these be lowered in SDL_mixer as well?
