### PR TITLE
Remove workarounds for OpenWatcom maths functions

### DIFF
--- a/src/SDL_sound_shn.c
+++ b/src/SDL_sound_shn.c
@@ -174,10 +174,6 @@ static const Uint8 ulaw_outward[13][256] = {
 #define M_PI    3.14159265358979323846
 #endif
 
-#if defined(HAVE_LIBC) && defined(__WATCOMC__) /* Watcom has issues... */
-#define SDL_log log
-#endif
-
 
 static int word_get(shn_t *shn, SDL_RWops *rw, Uint32 *word)
 {

--- a/src/SDL_sound_vorbis.c
+++ b/src/SDL_sound_vorbis.c
@@ -52,7 +52,6 @@
 #define malloc SDL_malloc
 #define realloc SDL_realloc
 #define free SDL_free
-#ifndef __WATCOMC__ /* #@!.!.. */
 #define pow SDL_pow
 #define floor SDL_floor
 #define ldexp(v, e) SDL_scalbn((v), (e))
@@ -62,7 +61,6 @@
 #define log(x) SDL_log(x)
 #if SDL_VERSION_ATLEAST(2, 0, 9)
 #define exp SDL_exp
-#endif
 #endif
 #endif
 

--- a/src/libmodplug/fastmix.c
+++ b/src/libmodplug/fastmix.c
@@ -9,9 +9,7 @@
 #include <math.h>
 
 #include "SDL_stdinc.h"
-#if !(defined(HAVE_LIBC) && defined(__WATCOMC__)) /* Watcom has issues... */
 #define floor SDL_floor
-#endif
 
 /*
  *-----------------------------------------------------------------------------

--- a/src/libmodplug/libmodplug.h
+++ b/src/libmodplug/libmodplug.h
@@ -12,16 +12,6 @@
 #define __SDL_SOUND_INTERNAL__
 #include "SDL_sound_internal.h"
 
-#if defined(HAVE_LIBC) && defined(__WATCOMC__) /* Watcom has issues... */
-#define SDL_cos  cos
-#define SDL_fabs fabs
-#define SDL_log  log
-#define SDL_pow  pow
-#define SDL_sin  sin
-#define SDL_sinf sin
-#define SDL_abs  abs
-#endif
-
 #ifdef _WIN32
 
 #ifdef _MSC_VER

--- a/src/timidity/tables.h
+++ b/src/timidity/tables.h
@@ -11,9 +11,6 @@
 #ifndef TIMIDITY_TABLES_H
 #define TIMIDITY_TABLES_H
 
-#if defined(HAVE_LIBC) && defined(__WATCOMC__) /* Watcom has issues... */
-#define SDL_sin  sin
-#endif
 #define timi_sine(x) (SDL_sin((2*PI/1024.0) * (x)))
 
 #define SINE_CYCLE_LENGTH 1024


### PR DESCRIPTION
These shouldn't be needed now that https://github.com/libsdl-org/SDL/issues/5667 is fixed.