### PR TITLE
Remove broken FreeBSD specific condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,11 +296,7 @@ if(SDLSOUND_BUILD_TEST)
     endif()
 endif()
 
-if(FREEBSD)
-    set(PKGCONFIG_INSTALLDIR "libdata/pkgconfig")
-else()
-    set(PKGCONFIG_INSTALLDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-endif()
+set(PKGCONFIG_INSTALLDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 if(WIN32 AND NOT MINGW)
     set(SDLSOUND_INSTALL_CMAKEDIR_DEFAULT "cmake")


### PR DESCRIPTION
There's no need to set FreeBSD-specific pkgconfig path as FreeBSD handles this by itself by moving the file into right location. Also the condition is always false as CMake does not define `FREEBSD` by default.