### PR TITLE
cmake: make sure SDL2_sound::SDL2_sound always exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,4 +413,9 @@ message_bool_option("Build static library" SDLSOUND_BUILD_STATIC)
 message_bool_option("Build shared library" SDLSOUND_BUILD_SHARED)
 message_bool_option("Build stdio test program" SDLSOUND_BUILD_TEST)
 
+# Make sure SDL2_sound::SDL2_sound always exists
+if(TARGET SDL2_sound::SDL2_sound-static AND NOT TARGET SDL2_sound::SDL2_sound)
+    add_library(SDL2_sound::SDL2_sound ALIAS SDL2_sound-static)
+endif()
+
 # end of CMakeLists.txt

--- a/cmake/SDL2_soundConfig.cmake.in
+++ b/cmake/SDL2_soundConfig.cmake.in
@@ -21,3 +21,14 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL2_sound-static-targets.cmake")
 endif()
 
 check_required_components(SDL2_sound)
+
+# Create SDL2_sound::SDL2_sound alias for static-only builds
+if(TARGET SDL2_sound::SDL2_sound-static AND NOT TARGET SDL2_sound::SDL2_sound)
+  if(CMAKE_VERSION VERSION_LESS "3.18")
+    # FIXME: Aliasing local targets is not supported on CMake < 3.18, so make it global.
+    add_library(SDL2_sound::SDL2_sound INTERFACE IMPORTED)
+    set_target_properties(SDL2_sound::SDL2_sound PROPERTIES INTERFACE_LINK_LIBRARIES "SDL2_sound::SDL2_sound-static")
+  else()
+    add_library(SDL2_sound::SDL2_sound ALIAS SDL2_sound::SDL2_sound-static)
+  endif()
+endif()


### PR DESCRIPTION
Fixes #89 

When SDL_sound gets branched for SDL3, there will be `SDL3_sound::SDL3_sound-shared`, `SDL3_sound::SDL3_sound-static` and `SDL3_sound::SDL3_sound`.