### PR TITLE
Fix ogg with extra buffer at end

### DIFF
--- a/src/SDL_sound_internal.h
+++ b/src/SDL_sound_internal.h
@@ -260,6 +260,7 @@ typedef struct __SOUND_SAMPLEINTERNAL__
     Uint32 buffer_size;
     void *decoder_private;
     Sint32 total_time;
+    Uint32 total_length;
     Uint32 mix_position;
     MixFunc mix;
 } Sound_SampleInternal;

--- a/src/SDL_sound_vorbis.c
+++ b/src/SDL_sound_vorbis.c
@@ -133,6 +133,7 @@ static int VORBIS_open(Sound_Sample *sample, const char *ext)
         const unsigned int rate = stb->sample_rate;
         internal->total_time = (num_frames / rate) * 1000;
         internal->total_time += (num_frames % rate) * 1000 / rate;
+        internal->total_length = num_frames;
     } /* else */
 
     return 1; /* we'll handle this data. */


### PR DESCRIPTION
There is a bug in stb_vorbis that I am not sure how to fix

https://github.com/icculus/SDL_sound/blob/fdcecafbfdcbdd2b77c5b591948c237df19c864e/src/stb_vorbis.h#L5651-L5658

The n that is added here at the end can be bigger than the size of the buffer. The `current_playback_loc` was added in https://github.com/nothings/stb/pull/1295, it will be wrong at the end, but it's correct before the last call where there are samples, so we can use that to workaround and get the true final length.

The other approach would be to push the truncation in stb_vorbis, inside `stb_vorbis_get_samples_float_interleaved`, the issue there is it would get stb_vorbis more different from it's upstream. I think the actual issue is `stb_vorbis_get_frame_float` is called and the result is dismissed, but that result would be the only other way to know the actual remaining length.

fix #92 