### PR TITLE
chore: update to use https

### DIFF
--- a/src/SDL_sound_modplug.c
+++ b/src/SDL_sound_modplug.c
@@ -220,7 +220,7 @@ const Sound_DecoderFunctions __Sound_DecoderFunctions_MODPLUG =
         extensions_modplug,
         "Play modules through ModPlug",
         "Torbjörn Andersson <d91tan@Update.UU.SE>",
-        "http://modplug-xmms.sourceforge.net/"
+        "https://modplug-xmms.sourceforge.net/"
     },
 
     MODPLUG_init,       /*   init() method */


### PR DESCRIPTION
https link should just work fine, thus updating to use it

```
$ curl -I https://modplug-xmms.sourceforge.net/
HTTP/2 200
date: Tue, 18 Jun 2024 23:17:39 GMT
```

relates to https://github.com/Homebrew/homebrew-core/pull/174799