### PR TITLE
CMake: Replace CMAKE_COMPILER_IS_GNUCC with CMAKE_C_COMPILER_ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ include(GNUInstallDirs)
 
 include_directories(src)
 
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+if(CMAKE_C_COMPILER_ID MATCHES "(Clang|^GNU$)")
     add_compile_options(-Wall)
 endif()
 


### PR DESCRIPTION
CMAKE_COMPILER_IS_GNUCC is obsolete variable and can be replaced with CMAKE_C_COMPILER_ID (also available since early CMake versions).

In the past CMake versions also LCC and QCC compilers had this varible set to boolean true but here these don't seem relevant.