### PR TITLE
timidity soundfont support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ if(SDLSOUND_DECODER_MIDI)
         src/timidity/playmidi.h
         src/timidity/readmidi.h
         src/timidity/resample.h
+        src/timidity/sbk.h
+        src/timidity/sflayer.h
         src/timidity/tables.h
         src/timidity/timidity.h
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ if(SDLSOUND_DECODER_MIDI)
         src/timidity/playmidi.c
         src/timidity/readmidi.c
         src/timidity/resample.c
+        src/timidity/readsbk.c
+        src/timidity/sndfont.c
         src/timidity/tables.c
         src/timidity/timidity.c
     )

--- a/src/SDL_sound_midi.c
+++ b/src/SDL_sound_midi.c
@@ -32,7 +32,13 @@
 static bool MIDI_init(void)
 {
     const char *cfg;
+    const char *sf2;
     int rc = -1;
+
+    sf2 = SDL_getenv("TIMIDITY_SOUNDFONT");
+    if (sf2) {
+        Timidity_SetSoundfont(sf2); /* user override, no cfg */
+    }
 
     cfg = SDL_getenv("TIMIDITY_CFG");
     if (cfg) {

--- a/src/timidity/README.sf
+++ b/src/timidity/README.sf
@@ -1,0 +1,70 @@
+================================================================
+	** Timidity SoundFont Extension **
+
+	    written by Takashi Iwai
+		<iwai@dragon.mm.t.u-tokyo.ac.jp>
+		<http://bahamut.mm.t.u-tokyo.ac.jp/~iwai/>
+
+	patch level 1: April 2, 1997
+================================================================
+
+* WHAT'S THIS?
+
+This is an extension to use samples in SoundFont files with
+timidity-0.2i.  You can employ both SoundFont file together with
+ordinary GUS patch files.  Both SBK and SF2 formats are supported.
+
+
+* USAGE
+
+Two commands are newly added in configuration.
+
+To specify the SoundFont file to be used, just add a line in config
+file like:
+
+	 soundfont sffile [order=number]
+
+The first parameter is the file name to be loaded.  The file itself
+is stored once after reading all configurations, then converted to
+the internal records except wave sample data.
+
+The optional argument specifies the order of searching.
+'order=0' means to search the SoundFont file at first, then search
+the GUS patches if the appropriate sample is not found.
+'order=1' means to search the SoundFont file after GUS patches.
+
+Another command 'font' is supplied to control the behavior of sample
+selection.  If you don't want to use some samples in the SoundFont
+file, specify the sample via 'exclude' sub-command.
+
+	font exclude bank [preset [keynote]]
+
+The first parameter is MIDI bank number of the sample to be removed.
+The optional second parameter is MIDI program number of the sample.
+For drum samples, specify 128 as bank, and drumset number as preset,
+and keynote number for the drum sample.
+
+You can change the order of individual sample (or bank) via "order"
+sub-command.
+
+	font order number bank [preset [keynote]]
+
+The first parameter is the order number (zero or one) to be changed,
+and the sequent parameters are as well as in exclude command above.
+
+
+* BUGS & TODO'S
+
+- noises on some bass drum samples
+- support of modulation envelope
+- support of cut off / resonance
+- support of chorus / reverb
+
+
+* CHANGES
+
+- pl.1
+	+ fix volume envelope calcuation
+	+ add font command
+	+ fix font-exclude control
+

--- a/src/timidity/instrum.c
+++ b/src/timidity/instrum.c
@@ -19,6 +19,7 @@
 #include "options.h"
 #include "common.h"
 #include "instrum.h"
+#include "sndfont.h"
 #include "resample.h"
 #include "tables.h"
 
@@ -209,6 +210,8 @@ static void load_instrument(MidiSong *song, const char *name,
   *out=SDL_malloc(sizeof(Instrument));
   ip = *out;
   if (!ip) goto nomem;
+
+  ip->type = INST_GUS;
 
   ip->samples = tmp[198];
   ip->sample = SDL_malloc(sizeof(Sample) * ip->samples);
@@ -544,6 +547,14 @@ static int fill_bank(MidiSong *song, int dr, int b)
 	    }
 	  else
 	    {
+	      /* preload soundfont */
+	      bank->instrument[i] = load_soundfont(song, 0,
+							(dr)? 128 : b,
+							(dr)? b : i,
+							(dr)? i : -1);
+	      if (bank->instrument[i])
+		continue;
+	      /* try gus patch */
 	      load_instrument(song,
 				     bank->tone[i].name, 
 				     &bank->instrument[i],
@@ -560,6 +571,13 @@ static int fill_bank(MidiSong *song, int dr, int b)
 				     bank->tone[i].strip_envelope :
 				     ((dr) ? 1 : -1),
 				     bank->tone[i].strip_tail);
+	      if (bank->instrument[i])
+		continue;
+	      /* no patch; search soundfont again. */
+	      bank->instrument[i] = load_soundfont(song, 1,
+							(dr)? 128 : b,
+							(dr)? b : i,
+							(dr)? i : -1);
 	      if (!bank->instrument[i]) {
 		SNDDBG(("Couldn't load instrument %s (%s %d, program %d)\n",
 		   bank->tone[i].name,

--- a/src/timidity/instrum.c
+++ b/src/timidity/instrum.c
@@ -553,7 +553,7 @@ static int fill_bank(MidiSong *song, int dr, int b)
 							(dr)? b : i,
 							(dr)? i : -1);
 	      if (bank->instrument[i])
-		continue;
+		  continue;
 	      /* try gus patch */
 	      load_instrument(song,
 				     bank->tone[i].name, 
@@ -572,7 +572,7 @@ static int fill_bank(MidiSong *song, int dr, int b)
 				     ((dr) ? 1 : -1),
 				     bank->tone[i].strip_tail);
 	      if (bank->instrument[i])
-		continue;
+		  continue;
 	      /* no patch; search soundfont again. */
 	      bank->instrument[i] = load_soundfont(song, 1,
 							(dr)? 128 : b,

--- a/src/timidity/playmidi.c
+++ b/src/timidity/playmidi.c
@@ -190,7 +190,6 @@ static int find_samples(MidiSong *song, MidiEvent *e, int *vlist)
 	{
 	  SNDDBG(("Strange: percussion instrument with %d samples!",
 		  ip->samples));
-	  return 0;
 	}
     }
   else

--- a/src/timidity/playmidi.c
+++ b/src/timidity/playmidi.c
@@ -177,7 +177,7 @@ static int find_samples(MidiSong *song, MidiEvent *e, int *vlist)
   Instrument *ip;
   Sample *sp, *closest;
   Sint32 f, cdiff, diff;
-  int i, nv, note;
+  int i, nv, maxnv, note;
 
   if (ISDRUMCHANNEL(song, e->channel))
     {
@@ -211,6 +211,7 @@ static int find_samples(MidiSong *song, MidiEvent *e, int *vlist)
   f = freq_table[note];
 
   nv = 0;
+  maxnv = (ip->type != INST_GUS) ? 32 : 1; /* GUS: emulate timidity-0.2i start_note() */
   for (i = 0, sp = ip->sample; i < ip->samples; i++, sp++)
     {
       if (sp->low_freq <= f && sp->high_freq >= f)
@@ -218,7 +219,7 @@ static int find_samples(MidiSong *song, MidiEvent *e, int *vlist)
 	  vlist[nv] = find_voice(song, e);
 	  song->voice[vlist[nv]].orig_frequency = f;
 	  song->voice[vlist[nv]].sample = sp;
-	  nv++;
+	  if (++nv == maxnv) break;
 	}
     }
 

--- a/src/timidity/playmidi.c
+++ b/src/timidity/playmidi.c
@@ -57,52 +57,6 @@ static void reset_midi(MidiSong *song)
   reset_voices(song);
 }
 
-static void select_sample(MidiSong *song, int v, Instrument *ip)
-{
-  Sint32 f, cdiff, diff;
-  int s,i;
-  Sample *sp, *closest;
-
-  s=ip->samples;
-  sp=ip->sample;
-
-  if (s==1)
-    {
-      song->voice[v].sample=sp;
-      return;
-    }
-
-  f=song->voice[v].orig_frequency;
-  for (i=0; i<s; i++, sp++)
-    {
-      if (sp->low_freq <= f && sp->high_freq >= f)
-	{
-	  song->voice[v].sample=sp;
-	  return;
-	}
-    }
-
-  /*
-     No suitable sample found! We'll select the sample whose root
-     frequency is closest to the one we want. (Actually we should
-     probably convert the low, high, and root frequencies to MIDI
-     note values and compare those.)
-   */
-  cdiff=0x7FFFFFFF;
-  closest=sp=ip->sample;
-  for(i=0; i<s; i++, sp++)
-    {
-      diff=sp->root_freq - f;
-      if (diff<0) diff=-diff;
-      if (diff<cdiff)
-	{
-	  cdiff=diff;
-	  closest=sp;
-	}
-    }
-  song->voice[v].sample=closest;
-}
-
 static void recompute_freq(MidiSong *song, int v)
 {
   int 
@@ -216,31 +170,28 @@ static void recompute_amp(MidiSong *song, int v)
     }
 }
 
-static void start_note(MidiSong *song, MidiEvent *e, int i)
+static int find_voice(MidiSong *song, MidiEvent *e);
+
+static int find_samples(MidiSong *song, MidiEvent *e, int *vlist)
 {
   Instrument *ip;
-  int j;
+  Sample *sp, *closest;
+  Sint32 f, cdiff, diff;
+  int i, nv, note;
 
   if (ISDRUMCHANNEL(song, e->channel))
     {
       if (!(ip=song->drumset[song->channel[e->channel].bank]->instrument[e->a]))
 	{
 	  if (!(ip=song->drumset[0]->instrument[e->a]))
-	    return; /* No instrument? Then we can't play. */
+	    return 0; /* No instrument? Then we can't play. */
 	}
-      if (ip->samples != 1)
+      if (ip->type == INST_GUS && ip->samples != 1)
 	{
 	  SNDDBG(("Strange: percussion instrument with %d samples!",
 		  ip->samples));
+	  return 0;
 	}
-
-      if (ip->sample->note_to_use) /* Do we have a fixed pitch? */
-	song->voice[i].orig_frequency = freq_table[(int)(ip->sample->note_to_use)];
-      else
-	song->voice[i].orig_frequency = freq_table[e->a & 0x7F];
-
-      /* drums are supposed to have only one sample */
-      song->voice[i].sample = ip->sample;
     }
   else
     {
@@ -250,15 +201,54 @@ static void start_note(MidiSong *song, MidiEvent *e, int i)
 		 instrument[song->channel[e->channel].program]))
 	{
 	  if (!(ip=song->tonebank[0]->instrument[song->channel[e->channel].program]))
-	    return; /* No instrument? Then we can't play. */
+	    return 0; /* No instrument? Then we can't play. */
 	}
-
-      if (ip->sample->note_to_use) /* Fixed-pitch instrument? */
-	song->voice[i].orig_frequency = freq_table[(int)(ip->sample->note_to_use)];
-      else
-	song->voice[i].orig_frequency = freq_table[e->a & 0x7F];
-      select_sample(song, i, ip);
     }
+
+  if (ip->sample->note_to_use)
+    note = ip->sample->note_to_use;
+  else
+    note = e->a & 0x7f;
+  f = freq_table[note];
+
+  nv = 0;
+  for (i = 0, sp = ip->sample; i < ip->samples; i++, sp++)
+    {
+      if (sp->low_freq <= f && sp->high_freq >= f)
+	{
+	  vlist[nv] = find_voice(song, e);
+	  song->voice[vlist[nv]].orig_frequency = f;
+	  song->voice[vlist[nv]].sample = sp;
+	  nv++;
+	}
+    }
+
+  if (nv == 0)
+    {
+      cdiff = 0x7FFFFFFF;
+      closest = sp = ip->sample;
+      for (i = 0; i < ip->samples; i++, sp++)
+	{
+	  diff = sp->root_freq - f;
+	  if (diff < 0) diff = -diff;
+	  if (diff < cdiff)
+	    {
+	      cdiff = diff;
+	      closest = sp;
+	    }
+	}
+      vlist[nv] = find_voice(song, e);
+      song->voice[vlist[nv]].orig_frequency = f;
+      song->voice[vlist[nv]].sample = closest;
+      nv++;
+    }
+
+  return nv;
+}
+
+static void start_note(MidiSong *song, MidiEvent *e, int i)
+{
+  int j;
 
   song->voice[i].status = VOICE_ON;
   song->voice[i].channel = e->channel;
@@ -308,11 +298,10 @@ static void kill_note(MidiSong *song, int i)
 }
 
 /* Only one instance of a note can be playing on a single channel. */
-static void note_on(MidiSong *song)
+static int find_voice(MidiSong *song, MidiEvent *e)
 {
   int i = song->voices, lowest=-1;
   Sint32 lv=0x7FFFFFFF, v;
-  MidiEvent *e = song->current_event;
 
   while (i--)
     {
@@ -326,8 +315,7 @@ static void note_on(MidiSong *song)
   if (lowest != -1)
     {
       /* Found a free voice. */
-      start_note(song,e,lowest);
-      return;
+      return lowest;
     }
 
   /* Look for the decaying note with the lowest volume */
@@ -358,11 +346,24 @@ static void note_on(MidiSong *song)
 
       song->cut_notes++;
       song->voice[lowest].status=VOICE_FREE;
-      start_note(song,e,lowest);
+      return lowest;
     }
   else
     song->lost_notes++;
+  return 0;
 }
+
+static void note_on(MidiSong *song)
+{
+  MidiEvent *e = song->current_event;
+  int i, nv;
+  int vlist[32];
+
+  nv = find_samples(song, e, vlist);
+  for (i = 0; i < nv; i++)
+    start_note(song, e, vlist[i]);
+}
+
 
 static void finish_note(MidiSong *song, int i)
 {
@@ -399,7 +400,6 @@ static void note_off(MidiSong *song)
 	  }
 	else
 	  finish_note(song, i);
-	return;
       }
 }
 

--- a/src/timidity/readsbk.c
+++ b/src/timidity/readsbk.c
@@ -338,11 +338,9 @@ static void process_chunk(int id, int s, SFInfo *sf, SDL_IOStream *io)
 				break;
 			/*
 			case INAM_ID:
-				sf->sf_name = (char*)SDL_malloc(subchunk.size);
-				if (sf->sf_name == NULL) {
-					SNDDBG(("can't malloc\n"));
-				}
+				sf->sf_name = (char *)SDL_malloc(subchunk.size + 1);
 				SDL_ReadIO(io, sf->sf_name, subchunk.size);
+				sf->sf_name[subchunk.size] = 0;
 				break;
 			*/
 			default:

--- a/src/timidity/readsbk.c
+++ b/src/timidity/readsbk.c
@@ -75,11 +75,12 @@ static void load_sample_info(int size, SFInfo *sf, SDL_IOStream *io);
 
 enum {
 	/* level 0 */
-	UNKN_ID, RIFF_ID, LIST_ID,
+	UNKN_ID, RIFF_ID, LIST_ID, SFBK_ID,
 	/* level 1 */
 	INFO_ID, SDTA_ID, PDTA_ID,
 	/* info stuff */
 	IFIL_ID, ISNG_ID, IROM_ID, INAM_ID, IVER_ID, IPRD_ID, ICOP_ID,
+	ICRD_ID, IENG_ID, ISFT_ID, ICMT_ID,
 	/* sample data stuff */
 	SNAM_ID, SMPL_ID,
 	/* preset stuff */
@@ -87,7 +88,7 @@ enum {
 	/* inst stuff */
 	INST_ID, IBAG_ID, IMOD_ID, IGEN_ID,
 	/* sample header */
-	SHDR_ID,
+	SHDR_ID
 };
 
 
@@ -175,7 +176,9 @@ static int getchunk(const char *id)
 		const char *str;
 		int id;
 	} idlist[] = {
+		{"RIFF", RIFF_ID},
 		{"LIST", LIST_ID},
+		{"sfbk", SFBK_ID},
 		{"INFO", INFO_ID},
 		{"sdta", SDTA_ID},
 		{"snam", SNAM_ID},
@@ -197,12 +200,17 @@ static int getchunk(const char *id)
 		{"INAM", INAM_ID},
 		{"IPRD", IPRD_ID},
 		{"ICOP", ICOP_ID},
+		{"ICRD", ICRD_ID},
+		{"IENG", IENG_ID},
+		{"ISFT", ISFT_ID},
+		{"ICMT", ICMT_ID},
 	};
+	static const int listsize = (int) sizeof(idlist)/sizeof(idlist[0]);
 
 	int i;
 
-	for (i = 0; i < sizeof(idlist)/sizeof(idlist[0]); i++) {
-		if (SDL_strncmp(id, idlist[i].str, 4) == 0) {
+	for (i = 0; i < listsize; i++) {
+		if (SDL_memcmp(id, idlist[i].str, 4) == 0) {
 			debugid("ok", id);
 			return idlist[i].id;
 		}

--- a/src/timidity/readsbk.c
+++ b/src/timidity/readsbk.c
@@ -278,8 +278,8 @@ static void load_gen(int size, SFInfo *sf, SDL_IOStream *io, int *totalp, tgenre
 	size /= 4;
 	buf = NEW(tgenrec, size);
 	for (i = 0; i < size; i++) {
-		READW(&buf[i].oper, io);
-		READW(&buf[i].amount, io);
+		READW((Uint16 *)&buf[i].oper, io);
+		READW((Uint16 *)&buf[i].amount, io);
 	}
 	*totalp = size;
 	*bufp = buf;

--- a/src/timidity/readsbk.c
+++ b/src/timidity/readsbk.c
@@ -124,13 +124,21 @@ static void debugval(const char *tag, int v)
  * load sbk file
  *----------------------------------------------------------------*/
 
-void load_sbk(SDL_IOStream *io, SFInfo *sf)
+int load_sbk(SDL_IOStream *io, SFInfo *sf)
 {
 	tchunk chunk, subchunk;
+	Sint64 len;
 
-	READID(sf->sbkh.riff, io);
-	READDW(&sf->sbkh.size, io);
-	READID(sf->sbkh.sfbk, io);
+	len = SDL_GetIOSize(io);
+	if (len < 32) /* better?? */
+		return -1;
+
+	READCHUNK(&chunk, io);
+	if (getchunk(chunk.id) != RIFF_ID) return -1;
+	if (chunk.size != len - 8) return -1;
+
+	READID(chunk.id, io);
+	if (getchunk(chunk.id) != SFBK_ID) return -1;
 
 	sf->in_rom = 1;
 	while (SDL_GetIOStatus(io) != SDL_IO_STATUS_EOF) {
@@ -143,6 +151,8 @@ void load_sbk(SDL_IOStream *io, SFInfo *sf)
 			break;
 		}
 	}
+
+	return 0;
 }
 
 

--- a/src/timidity/readsbk.c
+++ b/src/timidity/readsbk.c
@@ -45,7 +45,18 @@ static int READW(Uint16 *vp, SDL_IOStream *io)
 	return 1;
 }
 
-#define READSTR(var,io)	SDL_ReadIO(io, var, 20)
+static int READSTR(char *str, SDL_IOStream *io)
+{
+	int n;
+	if (SDL_ReadIO(io, str, 20) != 20) return -1;
+	str[19] = '\0';
+	n = (int) SDL_strlen(str);
+	while (n > 0 && str[n - 1] == ' ')
+		n--;
+	str[n] = '\0';
+	return n;
+}
+
 #define READID(var,io)	SDL_ReadIO(io, var, 4)
 #define READB(var,io)	SDL_ReadIO(io, var, 1)
 #define SKIPB(io)	SDL_SeekIO(io, 1, SDL_IO_SEEK_CUR);

--- a/src/timidity/readsbk.c
+++ b/src/timidity/readsbk.c
@@ -63,7 +63,7 @@ static int READSTR(char *str, SDL_IOStream *io)
 #define SKIPW(io)	SDL_SeekIO(io, 2, SDL_IO_SEEK_CUR);
 #define SKIPDW(io)	SDL_SeekIO(io, 4, SDL_IO_SEEK_CUR);
 
-static int getchunk(char *id);
+static int getchunk(const char *id);
 static void process_chunk(int id, int s, SFInfo *sf, SDL_IOStream *io);
 static void load_sample_names(int size, SFInfo *sf, SDL_IOStream *io);
 static void load_preset_header(int size, SFInfo *sf, SDL_IOStream *io);
@@ -96,19 +96,19 @@ enum {
  *----------------------------------------------------------------*/
 
 #if 0
-static void debugid(char *tag, char *p)
+static void debugid(const char *tag, const char *p)
 {
 	char buf[5]; SDL_strlcpy(buf, p, 5);
 	SDL_Log("[%s:%s]", tag, buf);
 }
 
-static void debugname(char *tag, char *p)
+static void debugname(const char *tag, const char *p)
 {
 	char buf[21]; SDL_strlcpy(buf, p, 21);
 	SDL_Log("[%s:%s]", tag, buf);
 }
 
-static void debugval(char *tag, int v)
+static void debugval(const char *tag, int v)
 {
 	SDL_Log("[%s:%d]", tag, v);
 }
@@ -169,10 +169,10 @@ void free_sbk(SFInfo *sf)
  * get id value
  *----------------------------------------------------------------*/
 
-static int getchunk(char *id)
+static int getchunk(const char *id)
 {
 	static struct idstring {
-		char *str;
+		const char *str;
 		int id;
 	} idlist[] = {
 		{"LIST", LIST_ID},

--- a/src/timidity/readsbk.c
+++ b/src/timidity/readsbk.c
@@ -1,0 +1,441 @@
+/*
+
+    TiMidity -- Experimental MIDI to WAVE converter
+    Copyright (C) 1995 Tuukka Toivonen <toivonen@clinet.fi>
+
+    readsbk.c: read soundfont file
+    Copyright (C) 1996,1997 Takashi Iwai
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the Perl Artistic License, available in COPYING.
+*/
+
+#define __SDL_SOUND_INTERNAL__
+#include "SDL_sound_internal.h"
+
+#include "timidity.h"
+#include "options.h"
+#include "common.h"
+#include "sbk.h"
+
+/*----------------------------------------------------------------
+ * function prototypes
+ *----------------------------------------------------------------*/
+
+#define NEW(type,nums)	(type*)SDL_calloc((nums), sizeof(type))
+
+static int READCHUNK(tchunk *vp, SDL_IOStream *io)
+{
+	if (SDL_ReadIO(io, vp, 8) != 8) return -1;
+	vp->size = SDL_Swap32LE(vp->size);
+	return 1;
+}
+
+static int READDW(Sint32 *vp, SDL_IOStream *io)
+{
+	if (SDL_ReadIO(io, vp, 4) != 4) return -1;
+	*vp = SDL_Swap32LE(*vp);
+	return 1;
+}
+
+static int READW(Uint16 *vp, SDL_IOStream *io)
+{
+	if (SDL_ReadIO(io, vp, 2) != 2) return -1;
+	*vp = SDL_Swap16LE(*vp);
+	return 1;
+}
+
+#define READSTR(var,io)	SDL_ReadIO(io, var, 20)
+#define READID(var,io)	SDL_ReadIO(io, var, 4)
+#define READB(var,io)	SDL_ReadIO(io, var, 1)
+#define SKIPB(io)	SDL_SeekIO(io, 1, SDL_IO_SEEK_CUR);
+#define SKIPW(io)	SDL_SeekIO(io, 2, SDL_IO_SEEK_CUR);
+#define SKIPDW(io)	SDL_SeekIO(io, 4, SDL_IO_SEEK_CUR);
+
+static int getchunk(char *id);
+static void process_chunk(int id, int s, SFInfo *sf, SDL_IOStream *io);
+static void load_sample_names(int size, SFInfo *sf, SDL_IOStream *io);
+static void load_preset_header(int size, SFInfo *sf, SDL_IOStream *io);
+static void load_inst_header(int size, SFInfo *sf, SDL_IOStream *io);
+static void load_bag(int size, SFInfo *sf, SDL_IOStream *io, int *totalp, Uint16 **bufp);
+static void load_gen(int size, SFInfo *sf, SDL_IOStream *io, int *totalp, tgenrec **bufp);
+static void load_sample_info(int size, SFInfo *sf, SDL_IOStream *io);
+
+
+enum {
+	/* level 0 */
+	UNKN_ID, RIFF_ID, LIST_ID,
+	/* level 1 */
+	INFO_ID, SDTA_ID, PDTA_ID,
+	/* info stuff */
+	IFIL_ID, ISNG_ID, IROM_ID, INAM_ID, IVER_ID, IPRD_ID, ICOP_ID,
+	/* sample data stuff */
+	SNAM_ID, SMPL_ID,
+	/* preset stuff */
+	PHDR_ID, PBAG_ID, PMOD_ID, PGEN_ID,
+	/* inst stuff */
+	INST_ID, IBAG_ID, IMOD_ID, IGEN_ID,
+	/* sample header */
+	SHDR_ID,
+};
+
+
+/*----------------------------------------------------------------
+ * debug routine
+ *----------------------------------------------------------------*/
+
+#if 0
+static void debugid(char *tag, char *p)
+{
+	char buf[5]; SDL_strlcpy(buf, p, 5);
+	SDL_Log("[%s:%s]", tag, buf);
+}
+
+static void debugname(char *tag, char *p)
+{
+	char buf[21]; SDL_strlcpy(buf, p, 21);
+	SDL_Log("[%s:%s]", tag, buf);
+}
+
+static void debugval(char *tag, int v)
+{
+	SDL_Log("[%s:%d]", tag, v);
+}
+#else
+#define debugid(t,s) /**/
+#define debugname(t,s) /**/
+#define debugval(t,v) /**/
+#endif
+
+
+/*----------------------------------------------------------------
+ * load sbk file
+ *----------------------------------------------------------------*/
+
+void load_sbk(SDL_IOStream *io, SFInfo *sf)
+{
+	tchunk chunk, subchunk;
+
+	READID(sf->sbkh.riff, io);
+	READDW(&sf->sbkh.size, io);
+	READID(sf->sbkh.sfbk, io);
+
+	sf->in_rom = 1;
+	while (SDL_GetIOStatus(io) != SDL_IO_STATUS_EOF) {
+		READID(chunk.id, io);
+		switch (getchunk(chunk.id)) {
+		case LIST_ID:
+			READDW(&chunk.size, io);
+			READID(subchunk.id, io);
+			process_chunk(getchunk(subchunk.id), chunk.size - 4, sf, io);
+			break;
+		}
+	}
+}
+
+
+/*----------------------------------------------------------------
+ * free buffer
+ *----------------------------------------------------------------*/
+
+void free_sbk(SFInfo *sf)
+{
+	SDL_free(sf->samplenames);
+	SDL_free(sf->presethdr);
+	SDL_free(sf->sampleinfo);
+	SDL_free(sf->insthdr);
+	SDL_free(sf->presetbag);
+	SDL_free(sf->instbag);
+	SDL_free(sf->presetgen);
+	SDL_free(sf->instgen);
+	/*SDL_free(sf->sf_name);*/
+	SDL_memset(sf, 0, sizeof(*sf));
+}
+
+
+
+/*----------------------------------------------------------------
+ * get id value
+ *----------------------------------------------------------------*/
+
+static int getchunk(char *id)
+{
+	static struct idstring {
+		char *str;
+		int id;
+	} idlist[] = {
+		{"LIST", LIST_ID},
+		{"INFO", INFO_ID},
+		{"sdta", SDTA_ID},
+		{"snam", SNAM_ID},
+		{"smpl", SMPL_ID},
+		{"pdta", PDTA_ID},
+		{"phdr", PHDR_ID},
+		{"pbag", PBAG_ID},
+		{"pmod", PMOD_ID},
+		{"pgen", PGEN_ID},
+		{"inst", INST_ID},
+		{"ibag", IBAG_ID},
+		{"imod", IMOD_ID},
+		{"igen", IGEN_ID},
+		{"shdr", SHDR_ID},
+		{"ifil", IFIL_ID},
+		{"isng", ISNG_ID},
+		{"irom", IROM_ID},
+		{"iver", IVER_ID},
+		{"INAM", INAM_ID},
+		{"IPRD", IPRD_ID},
+		{"ICOP", ICOP_ID},
+	};
+
+	int i;
+
+	for (i = 0; i < sizeof(idlist)/sizeof(idlist[0]); i++) {
+		if (SDL_strncmp(id, idlist[i].str, 4) == 0) {
+			debugid("ok", id);
+			return idlist[i].id;
+		}
+	}
+
+	debugid("xx", id);
+	return UNKN_ID;
+}
+
+
+static void load_sample_names(int size, SFInfo *sf, SDL_IOStream *io)
+{
+	int i;
+	sf->nrsamples = size / 20;
+	sf->samplenames = NEW(tsamplenames, sf->nrsamples);
+	for (i = 0; i < sf->nrsamples; i++) {
+		READSTR(sf->samplenames[i].name, io);
+	}
+}
+
+static void load_preset_header(int size, SFInfo *sf, SDL_IOStream *io)
+{
+	int i;
+	sf->nrpresets = size / 38;
+	sf->presethdr = NEW(tpresethdr, sf->nrpresets);
+	for (i = 0; i < sf->nrpresets; i++) {
+		READSTR(sf->presethdr[i].name, io);
+		READW(&sf->presethdr[i].preset, io);
+		READW(&sf->presethdr[i].bank, io);
+		READW(&sf->presethdr[i].bagNdx, io);
+		SKIPDW(io); /* lib */
+		SKIPDW(io); /* genre */
+		SKIPDW(io); /* morph */
+	}
+}
+
+static void load_inst_header(int size, SFInfo *sf, SDL_IOStream *io)
+{
+	int i;
+
+	sf->nrinsts = size / 22;
+	sf->insthdr = NEW(tinsthdr, sf->nrinsts);
+	for (i = 0; i < sf->nrinsts; i++) {
+		READSTR(sf->insthdr[i].name, io);
+		READW(&sf->insthdr[i].bagNdx, io);
+	}
+}
+
+static void load_bag(int size, SFInfo *sf, SDL_IOStream *io, int *totalp, Uint16 **bufp)
+{
+	Uint16 *buf;
+	int i;
+
+	(void) sf;
+	debugval("bagsize", size);
+	size /= 4;
+	buf = NEW(Uint16, size);
+	for (i = 0; i < size; i++) {
+		READW(&buf[i], io);
+		SKIPW(io); /* mod */
+	}
+	*totalp = size;
+	*bufp = buf;
+}
+
+static void load_gen(int size, SFInfo *sf, SDL_IOStream *io, int *totalp, tgenrec **bufp)
+{
+	tgenrec *buf;
+	int i;
+
+	(void) sf;
+	debugval("gensize", size);
+	size /= 4;
+	buf = NEW(tgenrec, size);
+	for (i = 0; i < size; i++) {
+		READW(&buf[i].oper, io);
+		READW(&buf[i].amount, io);
+	}
+	*totalp = size;
+	*bufp = buf;
+}
+
+static void load_sample_info(int size, SFInfo *sf, SDL_IOStream *io)
+{
+	int i;
+
+	debugval("infosize", size);
+	if (sf->version > 1) {
+		sf->nrinfos = size / 46;
+		sf->nrsamples = sf->nrinfos;
+		sf->sampleinfo = NEW(tsampleinfo, sf->nrinfos);
+		sf->samplenames = NEW(tsamplenames, sf->nrsamples);
+	}
+	else  {
+		sf->nrinfos = size / 16;
+		sf->sampleinfo = NEW(tsampleinfo, sf->nrinfos);
+	}
+
+	for (i = 0; i < sf->nrinfos; i++) {
+		if (sf->version > 1)
+			READSTR(sf->samplenames[i].name, io);
+		READDW(&sf->sampleinfo[i].startsample, io);
+		READDW(&sf->sampleinfo[i].endsample, io);
+		READDW(&sf->sampleinfo[i].startloop, io);
+		READDW(&sf->sampleinfo[i].endloop, io);
+		if (sf->version > 1) {
+			READDW(&sf->sampleinfo[i].samplerate, io);
+			READB(&sf->sampleinfo[i].originalPitch, io);
+			READB(&sf->sampleinfo[i].pitchCorrection, io);
+			READW(&sf->sampleinfo[i].samplelink, io);
+			READW(&sf->sampleinfo[i].sampletype, io);
+		} else {
+			if (sf->sampleinfo[i].startsample == 0)
+				sf->in_rom = 0;
+			sf->sampleinfo[i].startloop++;
+			sf->sampleinfo[i].endloop += 2;
+			sf->sampleinfo[i].samplerate = 44100;
+			sf->sampleinfo[i].originalPitch = 60;
+			sf->sampleinfo[i].pitchCorrection = 0;
+			sf->sampleinfo[i].samplelink = 0;
+			if (sf->in_rom)
+				sf->sampleinfo[i].sampletype = 0x8001;
+			else
+				sf->sampleinfo[i].sampletype = 1;
+		}
+	}
+}
+
+static void process_chunk(int id, int s, SFInfo *sf, SDL_IOStream *io)
+{
+	int cid;
+	tchunk subchunk;
+
+	(void) s;
+
+	switch (id) {
+	case INFO_ID:
+		READCHUNK(&subchunk, io);
+		while ((cid = getchunk(subchunk.id)) != LIST_ID) {
+			switch (cid) {
+			case IFIL_ID:
+				READW(&sf->version, io);
+				READW(&sf->minorversion, io);
+				break;
+			/*
+			case INAM_ID:
+				sf->sf_name = (char*)SDL_malloc(subchunk.size);
+				if (sf->sf_name == NULL) {
+					SNDDBG(("can't malloc\n"));
+				}
+				SDL_ReadIO(io, sf->sf_name, subchunk.size);
+				break;
+			*/
+			default:
+				SDL_SeekIO(io, subchunk.size, SDL_IO_SEEK_CUR);
+				break;
+			}
+			READCHUNK(&subchunk, io);
+			if (SDL_GetIOStatus(io) == SDL_IO_STATUS_EOF)
+				return;
+		}
+		SDL_SeekIO(io, -8, SDL_IO_SEEK_CUR); /* seek back */
+		break;
+
+	case SDTA_ID:
+		READCHUNK(&subchunk, io);
+		while ((cid = getchunk(subchunk.id)) != LIST_ID) {
+			switch (cid) {
+			case SNAM_ID:
+				if (sf->version > 1) {
+					SNDDBG(("**** version 2 has obsolete format??\n"));
+					SDL_SeekIO(io, subchunk.size, SDL_IO_SEEK_CUR);
+				} else
+					load_sample_names(subchunk.size, sf, io);
+				break;
+			case SMPL_ID:
+				sf->samplepos = SDL_TellIO(io);
+				sf->samplesize = subchunk.size;
+				SDL_SeekIO(io, subchunk.size, SDL_IO_SEEK_CUR);
+			}
+			READCHUNK(&subchunk, io);
+			if (SDL_GetIOStatus(io) == SDL_IO_STATUS_EOF)
+				return;
+		}
+		SDL_SeekIO(io, -8, SDL_IO_SEEK_CUR); /* seek back */
+		break;
+
+	case PDTA_ID:
+		READCHUNK(&subchunk, io);
+		while ((cid = getchunk(subchunk.id)) != LIST_ID) {
+			switch (cid) {
+			case PHDR_ID:
+				load_preset_header(subchunk.size, sf, io);
+				break;
+
+			case PBAG_ID:
+				load_bag(subchunk.size, sf, io,
+					 &sf->nrpbags, &sf->presetbag);
+				break;
+
+			case PMOD_ID: /* ignored */
+				SDL_SeekIO(io, subchunk.size, SDL_IO_SEEK_CUR);
+				break;
+
+			case PGEN_ID:
+				load_gen(subchunk.size, sf, io,
+					 &sf->nrpgens, &sf->presetgen);
+				break;
+
+			case INST_ID:
+				load_inst_header(subchunk.size, sf, io);
+				break;
+
+			case IBAG_ID:
+				load_bag(subchunk.size, sf, io,
+					 &sf->nribags, &sf->instbag);
+				break;
+
+			case IMOD_ID: /* ingored */
+				SDL_SeekIO(io, subchunk.size, SDL_IO_SEEK_CUR);
+				break;
+
+			case IGEN_ID:
+				load_gen(subchunk.size, sf, io,
+					 &sf->nrigens, &sf->instgen);
+				break;
+
+			case SHDR_ID:
+				load_sample_info(subchunk.size, sf, io);
+				break;
+
+			default:
+				SNDDBG(("unknown id\n"));
+				SDL_SeekIO(io, subchunk.size, SDL_IO_SEEK_CUR);
+				break;
+			}
+			READCHUNK(&subchunk, io);
+			if (SDL_GetIOStatus(io) == SDL_IO_STATUS_EOF) {
+				debugid("file", "EOF");
+				return;
+			}
+		}
+		SDL_SeekIO(io, -8, SDL_IO_SEEK_CUR); /* rewind */
+		break;
+	}
+}
+

--- a/src/timidity/sbk.h
+++ b/src/timidity/sbk.h
@@ -90,6 +90,9 @@ typedef struct _SFInfo {
  * functions
  *----------------------------------------------------------------*/
 
+#define load_sbk TIMI_NAMESPACE(load_sbk)
+#define free_sbk TIMI_NAMESPACE(free_sbk)
+
 int load_sbk(SDL_IOStream *io, SFInfo *sf);
 void free_sbk(SFInfo *sf);
 

--- a/src/timidity/sbk.h
+++ b/src/timidity/sbk.h
@@ -1,0 +1,96 @@
+/*
+
+    TiMidity -- Experimental MIDI to WAVE converter
+    Copyright (C) 1995 Tuukka Toivonen <toivonen@clinet.fi>
+
+    sbk.h: SoundFont(tm) file format
+    Copyright (C) 1996,1997 Takashi Iwai
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the Perl Artistic License, available in COPYING.
+*/
+
+#ifndef SBK_H_DEF
+#define SBK_H_DEF
+
+typedef struct _tchunk {
+	char id[4];
+	Sint32 size;
+} tchunk;
+
+typedef struct _tsbkheader {
+	char riff[4];	/* RIFF */
+	Sint32 size;	/* size of sbk after there bytes */
+	char sfbk[4];	/* sfbk id */
+} tsbkheader;
+
+typedef struct _tsamplenames {
+	char name[20];
+} tsamplenames;
+
+typedef struct _tpresethdr {
+	char name[20];
+	Uint16 preset, bank, bagNdx;
+	/*int lib, genre, morphology;*/ /* reserved */
+} tpresethdr;
+
+typedef struct _tsampleinfo {
+	Sint32 startsample, endsample;
+	Sint32 startloop, endloop;
+	/* ver.2 additional info */
+	Sint32 samplerate;
+	Uint8 originalPitch;
+	Uint8 pitchCorrection;
+	Uint16 samplelink;
+	Uint16 sampletype;  /*1=mono, 2=right, 4=left, 8=linked, $8000=ROM*/
+} tsampleinfo;
+
+typedef struct _tinsthdr {
+	char name[20];
+	Uint16 bagNdx;
+} tinsthdr;
+
+typedef struct _tgenrec {
+	Sint16 oper;
+	Sint16 amount;
+} tgenrec;
+
+
+typedef struct _SFInfo {
+	Uint16 version, minorversion;
+	Sint32 samplepos, samplesize;
+
+	int nrsamples;
+	tsamplenames *samplenames;
+
+	int nrpresets;
+	tpresethdr *presethdr;
+
+	int nrinfos;
+	tsampleinfo *sampleinfo;
+
+	int nrinsts;
+	tinsthdr *insthdr;
+
+	int nrpbags, nribags;
+	Uint16 *presetbag, *instbag;
+
+	int nrpgens, nrigens;
+	tgenrec *presetgen, *instgen;
+
+	tsbkheader sbkh;
+
+	/*char *sf_name;*/
+
+	int in_rom;
+} SFInfo;
+
+
+/*----------------------------------------------------------------
+ * functions
+ *----------------------------------------------------------------*/
+
+void load_sbk(SDL_IOStream *io, SFInfo *sf);
+void free_sbk(SFInfo *sf);
+
+#endif

--- a/src/timidity/sbk.h
+++ b/src/timidity/sbk.h
@@ -78,7 +78,7 @@ typedef struct _SFInfo {
 	int nrpgens, nrigens;
 	tgenrec *presetgen, *instgen;
 
-	tsbkheader sbkh;
+	/*tsbkheader sbkh;*/
 
 	/*char *sf_name;*/
 
@@ -90,7 +90,7 @@ typedef struct _SFInfo {
  * functions
  *----------------------------------------------------------------*/
 
-void load_sbk(SDL_IOStream *io, SFInfo *sf);
+int load_sbk(SDL_IOStream *io, SFInfo *sf);
 void free_sbk(SFInfo *sf);
 
 #endif

--- a/src/timidity/sflayer.h
+++ b/src/timidity/sflayer.h
@@ -1,0 +1,78 @@
+/*
+
+    TiMidity -- Experimental MIDI to WAVE converter
+    Copyright (C) 1995 Tuukka Toivonen <toivonen@clinet.fi>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the Perl Artistic License, available in COPYING.
+*/
+
+#ifndef SFLAYER_H_DEF /* sflayer.h: SoundFont layer structure */
+#define SFLAYER_H_DEF
+
+enum {
+	SF_startAddrs,         /* sample start address -4 (0 to * 0xffffff) */
+        SF_endAddrs,
+        SF_startloopAddrs,     /* loop start address -4 (0 to * 0xffffff) */
+        SF_endloopAddrs,       /* loop end address -3 (0 to * 0xffffff) */
+        SF_startAddrsHi,       /* high word of startAddrs */
+        SF_lfo1ToPitch,        /* main fm: lfo1-> pitch */
+        SF_lfo2ToPitch,        /* aux fm:  lfo2-> pitch */
+        SF_env1ToPitch,        /* pitch env: env1(aux)-> pitch */
+        SF_initialFilterFc,    /* initial filter cutoff */
+        SF_initialFilterQ,     /* filter Q */
+        SF_lfo1ToFilterFc,     /* filter modulation: lfo1 -> filter * cutoff */
+        SF_env1ToFilterFc,     /* filter env: env1(aux)-> filter * cutoff */
+        SF_endAddrsHi,         /* high word of endAddrs */
+        SF_lfo1ToVolume,       /* tremolo: lfo1-> volume */
+        SF_env2ToVolume,       /* Env2Depth: env2-> volume */
+        SF_chorusEffectsSend,  /* chorus */
+        SF_reverbEffectsSend,  /* reverb */
+        SF_panEffectsSend,     /* pan */
+        SF_auxEffectsSend,     /* pan auxdata (internal) */
+        SF_sampleVolume,       /* used internally */
+        SF_unused3,
+        SF_delayLfo1,          /* delay 0x8000-n*(725us) */
+        SF_freqLfo1,           /* frequency */
+        SF_delayLfo2,          /* delay 0x8000-n*(725us) */
+        SF_freqLfo2,           /* frequency */
+        SF_delayEnv1,          /* delay 0x8000 - n(725us) */
+        SF_attackEnv1,         /* attack */
+        SF_holdEnv1,             /* hold */
+        SF_decayEnv1,            /* decay */
+        SF_sustainEnv1,          /* sustain */
+        SF_releaseEnv1,          /* release */
+        SF_autoHoldEnv1,
+        SF_autoDecayEnv1,
+        SF_delayEnv2,            /* delay 0x8000 - n(725us) */
+        SF_attackEnv2,           /* attack */
+        SF_holdEnv2,             /* hold */
+        SF_decayEnv2,            /* decay */
+        SF_sustainEnv2,          /* sustain */
+        SF_releaseEnv2,          /* release */
+        SF_autoHoldEnv2,
+        SF_autoDecayEnv2,
+        SF_instrument,           /* */
+        SF_nop,
+        SF_keyRange,             /* */
+        SF_velRange,             /* */
+        SF_startloopAddrsHi,     /* high word of startloopAddrs */
+        SF_keynum,               /* */
+        SF_velocity,             /* */
+        SF_instVol,              /* */
+        SF_keyTuning,
+        SF_endloopAddrsHi,       /* high word of endloopAddrs */
+        SF_coarseTune,
+        SF_fineTune,
+        SF_sampleId,
+        SF_sampleFlags,
+        SF_samplePitch,          /* SF1 only */
+        SF_scaleTuning,
+        SF_keyExclusiveClass,
+        SF_rootKey,
+	SF_EOF,
+};
+
+#define SFPARM_SIZE	SF_EOF
+
+#endif

--- a/src/timidity/sndfont.c
+++ b/src/timidity/sndfont.c
@@ -865,7 +865,7 @@ static void convert_tremolo(MidiSong *song, Layer *lay, SFInfo *sf, SampleList *
 	if (sf->version == 1)
 		level = (120 * level) / 64;  /* to centibel */
 	/* centibel to linear */
-	sp->v.tremolo_depth = TO_LINEAR(level);
+	sp->v.tremolo_depth = (Uint8) TO_LINEAR(level);
 
 	/* frequency in mHz */
 	if (lay->set[SF_freqLfo1]) {

--- a/src/timidity/sndfont.c
+++ b/src/timidity/sndfont.c
@@ -1,0 +1,1019 @@
+/*
+
+    TiMidity -- Experimental MIDI to WAVE converter
+    Copyright (C) 1995 Tuukka Toivonen <toivonen@clinet.fi>
+
+    sndfont.c: SoundFont file extension
+    written by Takashi Iwai <iwai@dragon.mm.t.u-tokyo.ac.jp>
+    Copyright (C) 1996,1997 Takashi Iwai
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the Perl Artistic License, available in COPYING.
+*/
+
+#define __SDL_SOUND_INTERNAL__
+#include "SDL_sound_internal.h"
+
+#include "timidity.h"
+#include "options.h"
+#include "common.h"
+#include "tables.h"
+#include "instrum.h"
+#include "sbk.h"
+#include "sflayer.h"
+#include "sndfont.h"
+#include "resample.h"
+
+/*----------------------------------------------------------------
+ * compile flags
+ *----------------------------------------------------------------*/
+
+/*#define SF_CLOSE_EACH_FILE*/
+
+/*#define SF_SUPPRESS_ENVELOPE*/
+/*#define SF_SUPPRESS_TREMOLO*/
+/*#define SF_SUPPRESS_VIBRATO*/
+#define SF_SUPPRESS_CUTOFF
+
+/*----------------------------------------------------------------
+ * local parameters
+ *----------------------------------------------------------------*/
+
+typedef struct _Layer {
+	Sint16 val[SFPARM_SIZE];
+	Sint8 set[SFPARM_SIZE];
+} Layer;
+
+typedef struct _SampleList {
+	Sample v;
+	struct _SampleList *next;
+	Sint32 startsample, endsample;
+	Sint32 cutoff_freq;
+	float resonance;
+} SampleList;
+
+typedef struct _InstList {
+	int bank, preset, keynote;
+	int samples;
+	int order;
+	SampleList *slist;
+	struct _InstList *next;
+} InstList;
+
+typedef struct SFInsts {
+	char *fname;
+	SDL_IOStream *io;
+	Uint16 version, minorversion;
+	Sint32 samplepos, samplesize;
+	InstList *instlist;
+} SFInsts;
+
+typedef struct _SFExclude {
+	int bank, preset, keynote;
+	struct _SFExclude *next;
+} SFExclude;
+
+typedef struct _SFOrder {
+	int bank, preset, keynote;
+	int order;
+	struct _SFOrder *next;
+} SFOrder;
+
+
+/*----------------------------------------------------------------*/
+
+static void free_sample(InstList *ip);
+static Instrument *load_from_file(MidiSong *song, SFInsts *rec, InstList *ip);
+static int is_excluded(int bank, int preset, int keynote);
+static void free_exclude(void);
+static int is_ordered(int bank, int preset, int keynote);
+static void free_order(void);
+static void parse_preset(MidiSong *song, SFInsts *rec, SFInfo *sf, int preset, int order);
+static void parse_gen(Layer *lay, tgenrec *gen);
+static void parse_preset_layer(Layer *lay, SFInfo *sf, int idx);
+#if 0 /* not used */
+static void merge_layer(Layer *dst, Layer *src);
+#endif
+static int search_inst(Layer *lay);
+static void parse_inst(MidiSong *song, SFInsts *rec, Layer *pr_lay, SFInfo *sf, int preset, int inst, int order);
+static void parse_inst_layer(Layer *lay, SFInfo *sf, int idx);
+static int search_sample(Layer *lay);
+static void append_layer(Layer *dst, Layer *src, SFInfo *sf);
+static void make_inst(MidiSong *song, SFInsts *rec, Layer *lay, SFInfo *sf, int pr_idx, int in_idx, int order);
+static Sint32 calc_root_pitch(Layer *lay, SFInfo *sf, SampleList *sp);
+#ifndef SF_SUPPRESS_ENVELOPE
+static void convert_volume_envelope(MidiSong *song, Layer *lay, SFInfo *sf, SampleList *sp);
+#endif
+static Sint32 to_offset(int offset);
+static Sint32 calc_rate(MidiSong *song, int diff, int time);
+static Sint32 to_msec(Layer *lay, SFInfo *sf, int index);
+static float calc_volume(Layer *lay, SFInfo *sf);
+static Sint32 calc_sustain(Layer *lay, SFInfo *sf);
+#ifndef SF_SUPPRESS_TREMOLO
+static void convert_tremolo(MidiSong *song, Layer *lay, SFInfo *sf, SampleList *sp);
+#endif
+#ifndef SF_SUPPRESS_VIBRATO
+static void convert_vibrato(MidiSong *song, Layer *lay, SFInfo *sf, SampleList *sp);
+#endif
+#ifndef SF_SUPPRESS_CUTOFF
+static void do_lowpass(Sample *sp, Sint32 freq, float resonance);
+#endif
+static void calc_cutoff(Layer *lay, SFInfo *sf, SampleList *sp);
+static void calc_filterQ(Layer *lay, SFInfo *sf, SampleList *sp);
+
+/*----------------------------------------------------------------*/
+
+
+static SFInsts sfrec;
+static SFExclude *sfexclude;
+static SFOrder *sforder;
+
+#ifndef SF_SUPPRESS_CUTOFF
+static const int cutoff_allowed = 0;
+#endif
+
+
+void init_soundfont(MidiSong *song, const char *fname, int order)
+{
+	static SFInfo sfinfo;
+	int i;
+
+	SNDDBG(("init soundfonts `%s'\n", fname));
+
+	if ((sfrec.io = timi_openfile(fname)) == NULL) {
+		SNDDBG(("can't open soundfont file %s\n", fname));
+		return;
+	}
+	sfrec.fname = SDL_strdup(fname);
+	load_sbk(sfrec.io, &sfinfo);
+
+	for (i = 0; i < sfinfo.nrpresets; i++) {
+		int bank = sfinfo.presethdr[i].bank;
+		int preset = sfinfo.presethdr[i].preset;
+		if (is_excluded(bank, preset, -1))
+			continue;
+		if (bank == 128) {
+			if (!song->drumset[preset]) {
+				song->drumset[preset] = (ToneBank*)SDL_calloc(1, sizeof(ToneBank));
+				song->drumset[preset]->tone = (ToneBankElement *) SDL_calloc(128, sizeof(ToneBankElement));
+			}
+		} else {
+			if (!song->tonebank[bank]) {
+				song->tonebank[bank] = (ToneBank*)SDL_calloc(1, sizeof(ToneBank));
+				song->tonebank[bank]->tone = (ToneBankElement *) SDL_calloc(128, sizeof(ToneBankElement));
+			}
+		}
+		parse_preset(song, &sfrec, &sfinfo, i, order);
+	}
+
+	/* copy header info */
+	sfrec.version = sfinfo.version;
+	sfrec.minorversion = sfinfo.minorversion;
+	sfrec.samplepos = sfinfo.samplepos;
+	sfrec.samplesize = sfinfo.samplesize;
+
+	free_sbk(&sfinfo);
+
+#ifdef SF_CLOSE_EACH_FILE
+	SDL_CloseIO(sfrec.io);
+	sfrec.io = NULL;
+#endif
+}
+
+
+static void free_sample(InstList *ip)
+{
+	SampleList *sp, *snext;
+	for (sp = ip->slist; sp; sp = snext) {
+		snext = sp->next;
+		SDL_free(sp);
+	}
+	SDL_free(ip);
+}
+
+void end_soundfont(void)
+{
+	InstList *ip, *next;
+
+	if (sfrec.io) {
+		SDL_CloseIO(sfrec.io);
+		sfrec.io = NULL;
+	}
+	SDL_free(sfrec.fname);
+	sfrec.fname = NULL;
+
+	for (ip = sfrec.instlist; ip; ip = next) {
+		next = ip->next;
+		free_sample(ip);
+	}
+	sfrec.instlist = NULL;
+
+	free_exclude();
+	free_order();
+}
+
+
+/*----------------------------------------------------------------
+ * get converted instrument info and load the wave data from file
+ *----------------------------------------------------------------*/
+
+Instrument *load_soundfont(MidiSong *song, int order, int bank, int preset, int keynote)
+{
+	InstList *ip;
+	Instrument *inst = NULL;
+
+	if (sfrec.io == NULL) {
+		if (sfrec.fname == NULL)
+			return NULL;
+		if ((sfrec.io = timi_openfile(sfrec.fname)) == NULL) {
+			SNDDBG(("can't open soundfont file %s\n", sfrec.fname));
+			return NULL;
+		}
+	}
+
+	for (ip = sfrec.instlist; ip; ip = ip->next) {
+		if (ip->bank == bank && ip->preset == preset &&
+		    (keynote < 0 || keynote == ip->keynote) &&
+		    ip->order == order)
+			break;
+	}
+	if (ip && ip->samples)
+		inst = load_from_file(song, &sfrec, ip);
+
+#ifdef SF_CLOSE_EACH_FILE
+	SDL_CloseIO(sfrec.io);
+	sfrec.io = NULL;
+#endif
+
+	return inst;
+}
+
+
+static Instrument *load_from_file(MidiSong *song, SFInsts *rec, InstList *ip)
+{
+	SampleList *sp;
+	Instrument *inst;
+	int i;
+
+	SNDDBG(("Loading SF bank%d prg%d note%d\n", ip->bank, ip->preset, ip->keynote));
+
+	inst = (Instrument*)SDL_malloc(sizeof(Instrument));
+	inst->type = INST_SF2;
+	inst->samples = ip->samples;
+	inst->sample = (Sample*) SDL_calloc(ip->samples, sizeof(Sample));
+	for (i = 0, sp = ip->slist; i < ip->samples && sp; i++, sp = sp->next) {
+		Sample *sample = inst->sample + i;
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+		Sint32 j;
+		Sint16 *tmp, s;
+#endif
+		SDL_memcpy(sample, &sp->v, sizeof(Sample));
+		sample->data = (sample_t*) SDL_malloc(sp->endsample);
+		SDL_SeekIO(rec->io, sp->startsample, SDL_IO_SEEK_SET);
+		SDL_ReadIO(rec->io, sample->data, sp->endsample);
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+		tmp = (Sint16*)sample->data;
+		for (j = 0; j < sp->endsample/2; j++) {
+			s = SDL_Swap16LE(*tmp);
+			*tmp++ = s;
+		}
+#endif
+
+		/* do some filtering if necessary */
+#ifndef SF_SUPPRESS_CUTOFF
+		if (sp->cutoff_freq > 0 && cutoff_allowed) {
+			/* restore the normal value */
+			sample->data_length >>= FRACTION_BITS;
+			SNDDBG(("bank=%d, preset=%d, keynote=%d / cutoff = %d / resonance = %g\n",
+				ip->bank, ip->preset, ip->keynote, sp->cutoff_freq, sp->resonance));
+			do_lowpass(sample, sp->cutoff_freq, sp->resonance);
+			/* convert again to the fractional value */
+			sample->data_length <<= FRACTION_BITS;
+		}
+#endif
+
+		/* resample it if possible */
+		if (sample->note_to_use && !(sample->modes & MODES_LOOPING))
+			pre_resample(song, sample);
+	}
+	return inst;
+}
+
+
+/*----------------------------------------------------------------
+ * excluded samples
+ *----------------------------------------------------------------*/
+
+void exclude_soundfont(int bank, int preset, int keynote)
+{
+	SFExclude *rec;
+	rec = (SFExclude*)SDL_malloc(sizeof(SFExclude));
+	rec->bank = bank;
+	rec->preset = preset;
+	rec->keynote = keynote;
+	rec->next = sfexclude;
+	sfexclude = rec;
+}
+
+/* check the instrument is specified to be excluded */
+static int is_excluded(int bank, int preset, int keynote)
+{
+	SFExclude *p;
+	for (p = sfexclude; p; p = p->next) {
+		if (p->bank == bank &&
+		    (p->preset < 0 || p->preset == preset) &&
+		    (p->keynote < 0 || p->keynote == keynote))
+			return 1;
+	}
+	return 0;
+}
+
+/* free exclude list */
+static void free_exclude(void)
+{
+	SFExclude *p, *next;
+	for (p = sfexclude; p; p = next) {
+		next = p->next;
+		SDL_free(p);
+	}
+	sfexclude = NULL;
+}
+
+
+/*----------------------------------------------------------------
+ * ordered samples
+ *----------------------------------------------------------------*/
+
+void order_soundfont(int bank, int preset, int keynote, int order)
+{
+	SFOrder *rec;
+	rec = (SFOrder*)SDL_malloc(sizeof(SFOrder));
+	rec->bank = bank;
+	rec->preset = preset;
+	rec->keynote = keynote;
+	rec->order = order;
+	rec->next = sforder;
+	sforder = rec;
+}
+
+/* check the instrument is specified to be ordered */
+static int is_ordered(int bank, int preset, int keynote)
+{
+	SFOrder *p;
+	for (p = sforder; p; p = p->next) {
+		if (p->bank == bank &&
+		    (p->preset < 0 || p->preset == preset) &&
+		    (p->keynote < 0 || p->keynote == keynote))
+			return p->order;
+	}
+	return -1;
+}
+
+/* free order list */
+static void free_order(void)
+{
+	SFOrder *p, *next;
+	for (p = sforder; p; p = next) {
+		next = p->next;
+		SDL_free(p);
+	}
+	sforder = NULL;
+}
+
+
+/*----------------------------------------------------------------
+ * parse a preset
+ *----------------------------------------------------------------*/
+
+static void parse_preset(MidiSong *song, SFInsts *rec, SFInfo *sf, int preset, int order)
+{
+	int from_ndx, to_ndx;
+	Layer lay, glay;
+	int i, inst;
+
+	from_ndx = sf->presethdr[preset].bagNdx;
+	to_ndx = sf->presethdr[preset+1].bagNdx;
+
+	SDL_memset(&glay, 0, sizeof(glay));
+	for (i = from_ndx; i < to_ndx; i++) {
+		SDL_memset(&lay, 0, sizeof(Layer));
+		parse_preset_layer(&lay, sf, i);
+		inst = search_inst(&lay);
+		if (inst < 0) /* global layer */
+			SDL_memcpy(&glay, &lay, sizeof(Layer));
+		else {
+			append_layer(&lay, &glay, sf);
+			parse_inst(song, rec, &lay, sf, preset, inst, order);
+		}
+	}
+}
+
+/* map a generator operation to the layer structure */
+static void parse_gen(Layer *lay, tgenrec *gen)
+{
+	lay->set[gen->oper] = 1;
+	lay->val[gen->oper] = gen->amount;
+}
+
+/* parse preset generator layers */
+static void parse_preset_layer(Layer *lay, SFInfo *sf, int idx)
+{
+	int i;
+	for (i = sf->presetbag[idx]; i < sf->presetbag[idx+1]; i++)
+		parse_gen(lay, sf->presetgen + i);
+}
+
+/* merge two layers; never overrides on the destination */
+#if 0 /* not used */
+static void merge_layer(Layer *dst, Layer *src)
+{
+	int i;
+	for (i = 0; i < SFPARM_SIZE; i++) {
+		if (src->set[i] && !dst->set[i]) {
+			dst->val[i] = src->val[i];
+			dst->set[i] = 1;
+		}
+	}
+}
+#endif
+
+/* search instrument id from the layer */
+static int search_inst(Layer *lay)
+{
+	if (lay->set[SF_instrument])
+		return lay->val[SF_instrument];
+	else
+		return -1;
+}
+
+/* parse an instrument */
+static void parse_inst(MidiSong *song, SFInsts *rec, Layer *pr_lay, SFInfo *sf, int preset, int inst, int order)
+{
+	int from_ndx, to_ndx;
+	int i, sample;
+	Layer lay, glay;
+
+	from_ndx = sf->insthdr[inst].bagNdx;
+	to_ndx = sf->insthdr[inst+1].bagNdx;
+
+	SDL_memcpy(&glay, pr_lay, sizeof(Layer));
+	for (i = from_ndx; i < to_ndx; i++) {
+		SDL_memset(&lay, 0, sizeof(Layer));
+		parse_inst_layer(&lay, sf, i);
+		sample = search_sample(&lay);
+		if (sample < 0) /* global layer */
+			append_layer(&glay, &lay, sf);
+		else {
+			append_layer(&lay, &glay, sf);
+			make_inst(song, rec, &lay, sf, preset, inst, order);
+		}
+	}
+}
+
+/* parse instrument generator layers */
+static void parse_inst_layer(Layer *lay, SFInfo *sf, int idx)
+{
+	int i;
+	for (i = sf->instbag[idx]; i < sf->instbag[idx+1]; i++)
+		parse_gen(lay, sf->instgen + i);
+}
+
+/* search a sample id from instrument layers */
+static int search_sample(Layer *lay)
+{
+	if (lay->set[SF_sampleId])
+		return lay->val[SF_sampleId];
+	else
+		return -1;
+}
+
+
+/* two (high/low) 8 bit values in 16 bit parameter */
+#define LO_VAL(val)	((val) & 0xff)
+#define HI_VAL(val)	(((val) >> 8) & 0xff)
+#define SET_LO(vp,val)	((vp) = ((vp) & 0xff00) | (val))
+#define SET_HI(vp,val)	((vp) = ((vp) & 0xff) | ((val) << 8))
+
+/* append two layers; parameters are added to the original value */
+static void append_layer(Layer *dst, Layer *src, SFInfo *sf)
+{
+	int i;
+	for (i = 0; i < SFPARM_SIZE; i++) {
+		if (src->set[i]) {
+			if (sf->version == 1 && i == SF_instVol)
+				dst->val[i] = (src->val[i] * 127) / 127;
+			else if (i == SF_keyRange || i == SF_velRange) {
+				/* high limit */
+				if (HI_VAL(dst->val[i]) > HI_VAL(src->val[i]))
+					SET_HI(dst->val[i], HI_VAL(src->val[i]));
+				/* low limit */
+				if (LO_VAL(dst->val[i]) < LO_VAL(src->val[i]))
+					SET_LO(dst->val[i], LO_VAL(src->val[i]));
+			} else
+				dst->val[i] += src->val[i];
+			dst->set[i] = 1;
+		}
+	}
+}
+
+/* convert layer info to timidity instrument strucutre */
+static void make_inst(MidiSong *song, SFInsts *rec, Layer *lay, SFInfo *sf, int pr_idx, int in_idx, int order)
+{
+	int bank = sf->presethdr[pr_idx].bank;
+	int preset = sf->presethdr[pr_idx].preset;
+	int keynote, n_order;
+	char **namep;
+	InstList *ip;
+	tsampleinfo *sample;
+	SampleList *sp;
+
+	sample = &sf->sampleinfo[lay->val[SF_sampleId]];
+	if (sample->sampletype & 0x8000) /* is ROM sample? */
+		return;
+
+	/* set bank/preset name */
+	if (bank == 128) {
+		keynote = LO_VAL(lay->val[SF_keyRange]);
+		namep = &song->drumset[preset]->tone[keynote].name;
+	} else {
+		keynote = -1;
+		namep = &song->tonebank[bank]->tone[preset].name;
+	}
+	if (is_excluded(bank, preset, keynote))
+		return;
+	if ((n_order = is_ordered(bank, preset, keynote)) >= 0)
+		order = n_order;
+
+	if (*namep == NULL) {
+		*namep = (char*) SDL_malloc(21);
+		SDL_memcpy(*namep, sf->insthdr[in_idx].name, 20);
+		(*namep)[20] = 0;
+	}
+
+	/* search current instrument list */
+	for (ip = rec->instlist; ip; ip = ip->next) {
+		if (ip->bank == bank && ip->preset == preset &&
+		    (keynote < 0 || keynote == ip->keynote))
+			break;
+	}
+	if (ip == NULL) {
+		ip = (InstList*)SDL_malloc(sizeof(InstList));
+		ip->bank = bank;
+		ip->preset = preset;
+		ip->keynote = keynote;
+		ip->order = order;
+		ip->samples = 0;
+		ip->slist = NULL;
+		ip->next = rec->instlist;
+		rec->instlist = ip;
+	}
+
+	/* add a sample */
+	sp = (SampleList*)SDL_malloc(sizeof(SampleList));
+	sp->next = ip->slist;
+	ip->slist = sp;
+	ip->samples++;
+
+	/* set sample position */
+	sp->startsample = (lay->val[SF_startAddrsHi] << 16)
+		+ lay->val[SF_startAddrs]
+		+ sample->startsample;
+	sp->endsample = (lay->val[SF_endAddrsHi] << 16)
+		+ lay->val[SF_endAddrs]
+		+ sample->endsample - sp->startsample;
+
+	/* set loop position */
+	sp->v.loop_start = (lay->val[SF_startloopAddrsHi] << 16)
+		+ lay->val[SF_startloopAddrsHi]
+		+ sample->startloop - sp->startsample;
+	sp->v.loop_end = (lay->val[SF_endloopAddrsHi] << 16)
+		+ lay->val[SF_endloopAddrsHi]
+		+ sample->endloop - sp->startsample;
+	sp->v.data_length = sp->endsample;
+
+#if 0
+	if (sp->v.loop_start < 0)
+		SNDDBG(("negative loop pointer\n"));
+	if (sp->v.loop_start > sp->v.loop_end)
+		SNDDBG(("illegal loop position\n"));
+	if (sp->v.loop_end > sp->v.data_length)
+		SNDDBG(("illegal loop end or data size\n"));
+#endif
+
+	sp->v.sample_rate = sample->samplerate;
+	if (lay->set[SF_keyRange]) {
+		sp->v.low_freq = freq_table[LO_VAL(lay->val[SF_keyRange])];
+		sp->v.high_freq = freq_table[HI_VAL(lay->val[SF_keyRange])];
+	} else {
+		sp->v.low_freq = freq_table[0];
+		sp->v.high_freq = freq_table[127];
+	}
+
+	/* scale tuning: 0  - 100 */
+	sp->v.scale_tuning = 100;
+	if (lay->set[SF_scaleTuning]) {
+		if (sf->version == 1)
+			sp->v.scale_tuning = lay->val[SF_scaleTuning] ? 50 : 100;
+		else
+			sp->v.scale_tuning = lay->val[SF_scaleTuning];
+	}
+
+	/* root pitch */
+	sp->v.root_freq = calc_root_pitch(lay, sf, sp);
+
+	sp->v.modes = MODES_16BIT;
+
+	/* volume envelope & total volume */
+	sp->v.volume = calc_volume(lay,sf);
+	if (lay->val[SF_sampleFlags] == 1 || lay->val[SF_sampleFlags] == 3) {
+		sp->v.modes |= MODES_LOOPING|MODES_SUSTAIN;
+#ifndef SF_SUPPRESS_ENVELOPE
+		convert_volume_envelope(song, lay, sf, sp);
+#endif
+		if (lay->val[SF_sampleFlags] == 3)
+			/* strip the tail */
+			sp->v.data_length = sp->v.loop_end + 1;
+	}
+
+	/* panning position: 0 to 127 */
+	sp->v.panning = 64;
+	if (lay->set[SF_panEffectsSend]) {
+		if (sf->version == 1)
+			sp->v.panning = (Sint8)lay->val[SF_panEffectsSend];
+		else
+			sp->v.panning = (Sint8)(((int)lay->val[SF_panEffectsSend] + 500) * 127 / 1000);
+	}
+
+	/* tremolo & vibrato */
+	sp->v.tremolo_sweep_increment = 0;
+	sp->v.tremolo_phase_increment = 0;
+	sp->v.tremolo_depth = 0;
+#ifndef SF_SUPPRESS_TREMOLO
+	convert_tremolo(song, lay, sf, sp);
+#endif
+	sp->v.vibrato_sweep_increment = 0;
+	sp->v.vibrato_control_ratio = 0;
+	sp->v.vibrato_depth = 0;
+#ifndef SF_SUPPRESS_VIBRATO
+	convert_vibrato(song, lay, sf, sp);
+#endif
+
+	/* set note to use for drum voices */
+	if (bank == 128)
+		sp->v.note_to_use = keynote;
+	else
+		sp->v.note_to_use = 0;
+
+	/* convert to fractional samples */
+	sp->v.data_length <<= FRACTION_BITS;
+	sp->v.loop_start <<= FRACTION_BITS;
+	sp->v.loop_end <<= FRACTION_BITS;
+
+	/* point to the file position */
+	sp->startsample = sp->startsample * 2 + sf->samplepos;
+	sp->endsample *= 2;
+
+	/* set cutoff frequency */
+	sp->cutoff_freq = 0;
+	if (lay->set[SF_initialFilterFc] || lay->set[SF_env1ToFilterFc])
+		calc_cutoff(lay, sf, sp);
+	if (lay->set[SF_initialFilterQ])
+		calc_filterQ(lay, sf, sp);
+}
+
+/* calculate root pitch */
+static Sint32 calc_root_pitch(Layer *lay, SFInfo *sf, SampleList *sp)
+{
+	Sint32 root, tune;
+	tsampleinfo *sample;
+
+	sample = &sf->sampleinfo[lay->val[SF_sampleId]];
+
+	root = sample->originalPitch;
+	tune = sample->pitchCorrection;
+	if (sf->version == 1) {
+		if (lay->set[SF_samplePitch]) {
+			root = lay->val[SF_samplePitch] / 100;
+			tune = -lay->val[SF_samplePitch] % 100;
+			if (tune <= -50) {
+				root++;
+				tune = 100 + tune;
+			}
+			if (sp->v.scale_tuning == 50)
+				tune /= 2;
+		}
+		/* orverride root key */
+		if (lay->set[SF_rootKey])
+			root += lay->val[SF_rootKey] - 60;
+		/* tuning */
+		tune += lay->val[SF_coarseTune] * sp->v.scale_tuning +
+			lay->val[SF_fineTune] * sp->v.scale_tuning / 100;
+	} else {
+		/* orverride root key */
+		if (lay->set[SF_rootKey])
+			root = lay->val[SF_rootKey];
+		/* tuning */
+		tune += lay->val[SF_coarseTune] * 100
+			+ lay->val[SF_fineTune];
+	}
+	/* it's too high.. */
+	if (lay->set[SF_keyRange] &&
+	    root >= HI_VAL(lay->val[SF_keyRange]) + 60)
+		root -= 60;
+
+	while (tune <= -100) {
+		root++;
+		tune += 100;
+	}
+	while (tune > 0) {
+		root--;
+		tune -= 100;
+	}
+	return (Sint32)((double)freq_table[root] * bend_fine[(-tune*255)/100]);
+}
+
+
+#ifndef SF_SUPPRESS_ENVELOPE
+/*----------------------------------------------------------------
+ * convert volume envelope
+ *----------------------------------------------------------------*/
+
+static void convert_volume_envelope(MidiSong *song, Layer *lay, SFInfo *sf, SampleList *sp)
+{
+	Sint32 sustain = calc_sustain(lay, sf);
+	/*int delay = to_msec(lay, sf, SF_delayEnv2);*/
+	Sint32 attack = to_msec(lay, sf, SF_attackEnv2);
+	Sint32 hold = to_msec(lay, sf, SF_holdEnv2);
+	Sint32 decay = to_msec(lay, sf, SF_decayEnv2);
+	Sint32 release = to_msec(lay, sf, SF_releaseEnv2);
+
+	sp->v.envelope_offset[0] = to_offset(255);
+	sp->v.envelope_rate[0] = calc_rate(song, 255, attack) * 2;
+
+	sp->v.envelope_offset[1] = to_offset(250);
+	sp->v.envelope_rate[1] = calc_rate(song, 5, hold);
+	sp->v.envelope_offset[2] = to_offset(sustain);
+	sp->v.envelope_rate[2] = calc_rate(song, 250 - sustain, decay);
+	sp->v.envelope_offset[3] = to_offset(5);
+	sp->v.envelope_rate[3] = calc_rate(song, 255, release);
+	sp->v.envelope_offset[4] = to_offset(4);
+	sp->v.envelope_rate[4] = to_offset(200);
+	sp->v.envelope_offset[5] = to_offset(4);
+	sp->v.envelope_rate[5] = to_offset(200);
+
+	sp->v.modes |= MODES_ENVELOPE;
+}
+#endif
+
+/* convert from 8bit value to fractional offset (15.15) */
+static Sint32 to_offset(int offset)
+{
+	return (Sint32)offset << (7+15);
+}
+
+/* calculate ramp rate in fractional unit;
+ * diff = 8bit, time = msec
+ */
+static Sint32 calc_rate(MidiSong *song, int diff, int time)
+{
+	Sint32 rate;
+
+	if (time < 6) time = 6;
+	if (diff == 0) diff = 255;
+	diff <<= (7+15);
+	rate = (diff / song->rate) * song->control_ratio;
+	rate = rate * 1000 / time;
+#ifdef FAST_DECAY
+	rate *= 2;
+#endif
+
+	return rate;
+}
+
+
+#define TO_MSEC(tcents) (Sint32)(1000 * SDL_pow(2.0, (double)(tcents) / 1200.0))
+#define TO_MHZ(abscents) (Sint32)(8176.0 * SDL_pow(2.0,(double)(abscents)/1200.0))
+#define TO_HZ(abscents) (Sint32)(8.176 * SDL_pow(2.0,(double)(abscents)/1200.0))
+#define TO_LINEAR(centibel) SDL_pow(10.0, -(double)(centibel)/200.0)
+#define TO_VOLUME(centibel) (Uint8)(255 * (1.0 - (centibel) / (1200.0 * SDL_log10(2.0))));
+
+/* convert the value to milisecs */
+static Sint32 to_msec(Layer *lay, SFInfo *sf, int index)
+{
+	Sint16 value;
+	if (! lay->set[index])
+		return 6;  /* 6msec minimum */
+	value = lay->val[index];
+	if (sf->version == 1)
+		return value;
+	else
+		return TO_MSEC(value);
+}
+
+/* convert peak volume to linear volume (0-255) */
+static float calc_volume(Layer *lay, SFInfo *sf)
+{
+	if (sf->version == 1)
+		return (float)(lay->val[SF_instVol] * 2) / 255.0;
+	else
+		return TO_LINEAR((double)lay->val[SF_instVol] / 10.0);
+}
+
+/* convert sustain volume to linear volume */
+static Sint32 calc_sustain(Layer *lay, SFInfo *sf)
+{
+	Sint32 level;
+	if (!lay->set[SF_sustainEnv2])
+		return 250;
+	level = lay->val[SF_sustainEnv2];
+	if (sf->version == 1) {
+		if (level < 96)
+			level = 1000 * (96 - level) / 96;
+		else
+			return 0;
+	}
+	return TO_VOLUME(level);
+}
+
+
+#ifndef SF_SUPPRESS_TREMOLO
+/*----------------------------------------------------------------
+ * tremolo (LFO1) conversion
+ *----------------------------------------------------------------*/
+
+static void convert_tremolo(MidiSong *song, Layer *lay, SFInfo *sf, SampleList *sp)
+{
+	Sint32 level, freq;
+
+	(void) song;
+
+	if (!lay->set[SF_lfo1ToVolume])
+		return;
+
+	level = lay->val[SF_lfo1ToVolume];
+	if (sf->version == 1)
+		level = (120 * level) / 64;  /* to centibel */
+	/* centibel to linear */
+	sp->v.tremolo_depth = TO_LINEAR(level);
+
+	/* frequency in mHz */
+	if (lay->set[SF_freqLfo1]) {
+		if (sf->version == 1)
+			freq = TO_MHZ(-725);
+		else
+			freq = 0;
+	} else {
+		freq = lay->val[SF_freqLfo1];
+		if (freq > 0 && sf->version == 1)
+			freq = (int)(3986.0 * SDL_log10((double)freq) - 7925.0);
+		freq = TO_MHZ(freq);
+	}
+	/* convert mHz to sine table increment; 1024<<rate_shift=1wave */
+	sp->v.tremolo_phase_increment = (freq * 1024) << RATE_SHIFT;
+
+	sp->v.tremolo_sweep_increment = 0;
+}
+#endif
+
+
+#ifndef SF_SUPPRESS_VIBRATO
+/*----------------------------------------------------------------
+ * vibrato (LFO2) conversion
+ *----------------------------------------------------------------*/
+
+static void convert_vibrato(MidiSong *song, Layer *lay, SFInfo *sf, SampleList *sp)
+{
+	Sint32 shift, freq;
+
+	if (!lay->set[SF_lfo2ToPitch])
+		return;
+
+	/* pitch shift in cents (= 1/100 semitone) */
+	shift = lay->val[SF_lfo2ToPitch];
+	if (sf->version == 1)
+		shift = (1200 * shift / 64 + 1) / 2;
+
+	/* cents to linear; 400cents = 256 */
+	sp->v.vibrato_depth = (Sint8)((Sint32)shift * 256 / 400);
+
+	/* frequency in mHz */
+	if (lay->set[SF_freqLfo2]) {
+		if (sf->version == 1)
+			freq = TO_MHZ(-725);
+		else
+			freq = 0;
+	} else {
+		freq = lay->val[SF_freqLfo2];
+		if (freq > 0 && sf->version == 1)
+			freq = (int)(3986.0 * SDL_log10((double)freq) - 7925.0);
+		freq = TO_MHZ(freq);
+	}
+	/* convert mHz to control ratio */
+	sp->v.vibrato_control_ratio = freq *
+		(VIBRATO_RATE_TUNING * song->rate) /
+		(2 * VIBRATO_SAMPLE_INCREMENTS);
+
+	sp->v.vibrato_sweep_increment = 0;
+}
+#endif
+
+
+/* calculate cutoff/resonance frequency */
+static void calc_cutoff(Layer *lay, SFInfo *sf, SampleList *sp)
+{
+	Sint16 val;
+	if (! lay->set[SF_initialFilterFc]) {
+		val = 13500;
+	} else {
+		val = lay->val[SF_initialFilterFc];
+		if (sf->version == 1) {
+			if (val == 127)
+				val = 14400;
+			else if (val > 0)
+				val = 50 * val + 4366;
+		}
+	}
+	if (lay->set[SF_env1ToFilterFc]) {
+		val += lay->val[SF_env1ToFilterFc];
+	}
+	if (val >= 13500)
+		sp->cutoff_freq = 0;
+	else
+		sp->cutoff_freq = TO_HZ(val);
+}
+
+static void calc_filterQ(Layer *lay, SFInfo *sf, SampleList *sp)
+{
+	Sint16 val = lay->val[SF_initialFilterQ];
+	if (sf->version == 1)
+		val = val * 3 / 2; /* to centibels */
+	sp->resonance = SDL_pow(10.0, (double)val / 2.0 / 200.0) - 1;
+	if (sp->resonance < 0)
+		sp->resonance = 0;
+}
+
+
+#ifndef SF_SUPPRESS_CUTOFF
+/*----------------------------------------------------------------
+ * low-pass filter:
+ * 	y(n) = A * x(n) + B * y(n-1)
+ * 	A = 2.0 * pi * center
+ * 	B = exp(-A / frequency)
+ *----------------------------------------------------------------
+ * resonance filter:
+ *	y(n) = a * x(n) - b * y(n-1) - c * y(n-2)
+ *	c = exp(-2 * pi * width / rate)
+ *	b = -4 * c / (1+c) * cos(2 * pi * center / rate)
+ *	a = sqt(1-b*b/(4 * c)) * (1-c)
+ *----------------------------------------------------------------*/
+
+#define MAX_DATAVAL 32767
+#define MIN_DATAVAL -32768
+
+static void do_lowpass(Sample *sp, Sint32 freq, float resonance)
+{
+	double A, B, C;
+	sample_t *buf, pv1, pv2;
+	Sint32 i;
+
+	if (freq > sp->sample_rate * 2) {
+		SNDDBG(("Lowpass: center must be < data rate*2\n"));
+		return;
+	}
+	A = 2.0 * M_PI * freq * 2.5 / sp->sample_rate;
+	B = exp(-A / sp->sample_rate);
+	A *= 0.8;
+	B *= 0.8;
+	C = 0;
+
+	/*
+	if (resonance) {
+		double a, b, c;
+		Sint32 width;
+		width = freq / 5;
+		c = exp(-2.0 * M_PI * width / sp->sample_rate);
+		b = -4.0 * c / (1+c) * cos(2.0 * M_PI * freq / sp->sample_rate);
+		a = sqrt(1 - b * b / (4 * c)) * (1 - c);
+		b = -b; c = -c;
+
+		A += a * resonance;
+		B += b;
+		C = c;
+	}
+	*/(void) resonance;
+
+	pv1 = 0;
+	pv2 = 0;
+	buf = sp->data;
+	for (i = 0; i < sp->data_length; i++) {
+		sample_t l = *buf;
+		double d = A * l + B * pv1 + C * pv2;
+		if (d > MAX_DATAVAL)
+			d = MAX_DATAVAL;
+		else if (d < MIN_DATAVAL)
+			d = MIN_DATAVAL;
+		pv2 = pv1;
+		pv1 = *buf++ = (sample_t)d;
+	}
+}
+#endif

--- a/src/timidity/sndfont.c
+++ b/src/timidity/sndfont.c
@@ -147,7 +147,7 @@ void init_soundfont(MidiSong *song, const char *fname, int order)
 	sfrec.fname = SDL_strdup(fname);
 	load_sbk(sfrec.io, &sfinfo);
 
-	for (i = 0; i < sfinfo.nrpresets; i++) {
+	for (i = 0; i < sfinfo.nrpresets - 1; i++) {
 		int bank = sfinfo.presethdr[i].bank;
 		int preset = sfinfo.presethdr[i].preset;
 		if (is_excluded(bank, preset, -1))

--- a/src/timidity/sndfont.c
+++ b/src/timidity/sndfont.c
@@ -145,7 +145,15 @@ void init_soundfont(MidiSong *song, const char *fname, int order)
 		return;
 	}
 	sfrec.fname = SDL_strdup(fname);
-	load_sbk(sfrec.io, &sfinfo);
+	if (load_sbk(sfrec.io, &sfinfo) < 0) {
+		SNDDBG(("%s: bad soundfont file\n", fname));
+		SDL_CloseIO(sfrec.io);
+		sfrec.io = NULL;
+		SDL_free(sfrec.fname);
+		sfrec.fname = NULL;
+		free_sbk(&sfinfo);
+		return;
+	}
 
 	for (i = 0; i < sfinfo.nrpresets - 1; i++) {
 		int bank = sfinfo.presethdr[i].bank;

--- a/src/timidity/sndfont.c
+++ b/src/timidity/sndfont.c
@@ -268,9 +268,12 @@ static Instrument *load_from_file(MidiSong *song, SFInsts *rec, InstList *ip)
 		Sint16 *tmp, s;
 #endif
 		SDL_memcpy(sample, &sp->v, sizeof(Sample));
-		sample->data = (sample_t*) SDL_malloc(sp->endsample);
+		sample->data = (sample_t*) SDL_malloc(sp->endsample + 6);
 		SDL_SeekIO(rec->io, sp->startsample, SDL_IO_SEEK_SET);
 		SDL_ReadIO(rec->io, sample->data, sp->endsample);
+		/* initialize the 3 extra samples at the end (those +6 bytes) */
+		sample->data[sp->endsample/2] = sample->data[sp->endsample/2 + 1] =
+		sample->data[sp->endsample/2 + 2] = 0;
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
 		tmp = (Sint16*)sample->data;
 		for (j = 0; j < sp->endsample/2; j++) {

--- a/src/timidity/sndfont.cfg
+++ b/src/timidity/sndfont.cfg
@@ -1,0 +1,19 @@
+#----------------------------------------------------------------
+# SoundFont extension configuration
+#
+# soundfont <filename> [order=<number>]
+#    filename is the path of SoundFont file.
+#    number is 0(preload) or 1(load after GUS).
+#
+# font exclude <bank> [<preset> [<keynote>]]
+# font order <number> <bank> [<preset> [<keynote>]]
+#----------------------------------------------------------------
+
+soundfont /usr/local/lib/sfbank/chaos4m.sf2
+
+# remove chaos drumset
+font exclude 128 99
+
+# load drum samples after GUS patches
+font order 1 128
+

--- a/src/timidity/sndfont.h
+++ b/src/timidity/sndfont.h
@@ -10,6 +10,12 @@
 #ifndef TIMIDITY_SNDFONT_H /* sndfont.h: soundfont loader public api */
 #define TIMIDITY_SNDFONT_H
 
+#define init_soundfont    TIMI_NAMESPACE(init_soundfont)
+#define end_soundfont     TIMI_NAMESPACE(end_soundfont)
+#define load_soundfont    TIMI_NAMESPACE(load_soundfont)
+#define exclude_soundfont TIMI_NAMESPACE(exclude_soundfont)
+#define order_soundfont   TIMI_NAMESPACE(order_soundfont)
+
 void init_soundfont(MidiSong *song, const char *fname, int order);
 void end_soundfont(void);
 Instrument *load_soundfont(MidiSong *song, int order, int bank, int preset, int keynote);

--- a/src/timidity/sndfont.h
+++ b/src/timidity/sndfont.h
@@ -1,0 +1,19 @@
+/*
+
+    TiMidity -- Experimental MIDI to WAVE converter
+    Copyright (C) 1995 Tuukka Toivonen <toivonen@clinet.fi>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the Perl Artistic License, available in COPYING.
+*/
+
+#ifndef TIMIDITY_SNDFONT_H /* sndfont.h: soundfont loader public api */
+#define TIMIDITY_SNDFONT_H
+
+void init_soundfont(MidiSong *song, const char *fname, int order);
+void end_soundfont(void);
+Instrument *load_soundfont(MidiSong *song, int order, int bank, int preset, int keynote);
+void exclude_soundfont(int bank, int preset, int keynote);
+void order_soundfont(int bank, int preset, int keynote, int order);
+
+#endif /* TIMIDITY_SNDFONT_H */

--- a/src/timidity/timidity.c
+++ b/src/timidity/timidity.c
@@ -306,7 +306,10 @@ static int read_config_file(const char *name, int rcf_count)
 	SNDDBG(("%s: line %d: No soundfont file given\n", name, line));
 	goto fail;
       }
-      SDL_free(sf_file);
+      if (sf_file) {
+	SNDDBG(("%s: line %d: Ignoring multiple \"soundfont\" directives.\n", name, line));
+      }
+     else {
       sf_file=SDL_strdup(w[1]);
       for (j = 2; j < words; j++) {
 	if (!(cp = SDL_strchr(w[j], '='))) {
@@ -323,6 +326,7 @@ static int read_config_file(const char *name, int rcf_count)
 	  sf_order = k;
 	}
       }
+     }
     }
     else if (!SDL_strcmp(w[0], "font"))
     {

--- a/src/timidity/timidity.c
+++ b/src/timidity/timidity.c
@@ -14,6 +14,7 @@
 #include "options.h"
 #include "common.h"
 #include "instrum.h"
+#include "sndfont.h"
 #include "playmidi.h"
 #include "readmidi.h"
 #include "output.h"
@@ -58,6 +59,9 @@ static char *RWgets(SDL_IOStream *io, char *s, int size)
 
     return (num_read != 0) ? s : NULL;
 }
+
+static char *sf_file = NULL;
+static int sf_order = 0;
 
 static int read_config_file(const char *name, int rcf_count)
 {
@@ -197,17 +201,6 @@ static int read_config_file(const char *name, int rcf_count)
        */
       SNDDBG(("FIXME: Implement \"altassign\" in TiMidity config.\n"));
     }
-    else if (!SDL_strcmp(w[0], "soundfont") ||
-             !SDL_strcmp(w[0], "font"))
-    {
-      /* "soundfont" sf_file "remove"
-       * "soundfont" sf_file ["order=" order] ["cutoff=" cutoff]
-       *                     ["reso=" reso] ["amp=" amp]
-       * "font" "exclude" bank preset keynote
-       * "font" "order" order bank preset keynote
-       */
-      SNDDBG(("FIXME: Implmement \"%s\" in TiMidity config.\n", w[0]));
-    }
     else if (!SDL_strcmp(w[0], "progbase"))
     {
       /* The documentation for this makes absolutely no sense to me, but
@@ -306,6 +299,59 @@ static int read_config_file(const char *name, int rcf_count)
 	if (!master_tonebank[i]->tone) goto fail;
       }
       bank=master_tonebank[i];
+    }
+    else if (!SDL_strcmp(w[0], "soundfont"))
+    {
+      if (words < 2) {
+	SNDDBG(("%s: line %d: No soundfont file given\n", name, line));
+	goto fail;
+      }
+      SDL_free(sf_file);
+      sf_file=SDL_strdup(w[1]);
+      for (j = 2; j < words; j++) {
+	if (!(cp = SDL_strchr(w[j], '='))) {
+	  SNDDBG(("%s: line %d: bad patch option %s\n", name, line, w[j]));
+	  goto fail;
+	}
+	*cp++=0;
+	if (!SDL_strcmp(w[j], "order")) {
+	  k = SDL_atoi(cp);
+	  if (k < 0 || (*cp < '0' || *cp > '9')) {
+	    SNDDBG(("%s: line %d: order must be a digit", name, line));
+	    goto fail;
+	  }
+	  sf_order = k;
+	}
+      }
+    }
+    else if (!SDL_strcmp(w[0], "font"))
+    {
+      int bank, preset, keynote;
+      if (words < 2) {
+	SNDDBG(("%s: line %d: no font command\n", name, line));
+	goto fail;
+      }
+      if (!SDL_strcmp(w[1], "exclude")) {
+	if (words < 3) {
+	  SNDDBG(("%s: line %d: No bank/preset/key is given\n", name, line));
+	  goto fail;
+	}
+	bank = SDL_atoi(w[2]);
+	preset = (words >= 4)? SDL_atoi(w[3]) : -1;
+	keynote = (words >= 5)? SDL_atoi(w[4]) : -1;
+	exclude_soundfont(bank, preset, keynote);
+      } else if (!SDL_strcmp(w[1], "order")) {
+	int order;
+	if (words < 4) {
+	  SNDDBG(("%s: line %d: No order/bank is given\n", name, line));
+	  goto fail;
+	}
+	order = SDL_atoi(w[2]);
+	bank = SDL_atoi(w[3]);
+	preset = (words >= 5)? SDL_atoi(w[4]) : -1;
+	keynote = (words >= 6)? SDL_atoi(w[5]) : -1;
+	order_soundfont(bank, preset, keynote, order);
+      }
     }
     else
     {
@@ -606,6 +652,9 @@ static void do_song_load(SDL_IOStream *io, SDL_AudioSpec *audio, MidiSong **out)
   song->default_instrument = NULL;
   song->default_program = DEFAULT_PROGRAM;
 
+  if (sf_file)
+    init_soundfont(song, sf_file, sf_order);
+
   if (*def_instr_name)
     set_default_instrument(song, def_instr_name);
 
@@ -673,6 +722,10 @@ void Timidity_Exit(void)
       master_drumset[i] = NULL;
     }
   }
+
+  SDL_free(sf_file);
+  sf_file = NULL;
+  sf_order = 0;
 
   timi_free_pathlist();
 }

--- a/src/timidity/timidity.c
+++ b/src/timidity/timidity.c
@@ -676,13 +676,23 @@ MidiSong *Timidity_LoadSong(SDL_IOStream *io, SDL_AudioSpec *audio)
 
 void Timidity_FreeSong(MidiSong *song)
 {
-  int i;
+  int i, j;
 
   if (!song) return;
 
   free_instruments(song);
 
   for (i = 0; i < 128; i++) {
+    if (!master_tonebank[i] && song->tonebank[i]) { /* might be alloc'ed by sndfont */
+      for (j = 0; j < 128; j++)
+        SDL_free(song->tonebank[i]->tone[j].name);
+      SDL_free(song->tonebank[i]->tone);
+    }
+    if (!master_drumset[i] && song->drumset[i]) {   /* might be alloc'ed by sndfont */
+      for (j = 0; j < 128; j++)
+        SDL_free(song->drumset[i]->tone[j].name);
+      SDL_free(song->drumset[i]->tone);
+    }
     SDL_free(song->tonebank[i]);
     SDL_free(song->drumset[i]);
   }
@@ -723,6 +733,7 @@ void Timidity_Exit(void)
     }
   }
 
+  end_soundfont();
   SDL_free(sf_file);
   sf_file = NULL;
   sf_order = 0;

--- a/src/timidity/timidity.c
+++ b/src/timidity/timidity.c
@@ -547,10 +547,26 @@ int Timidity_Init(const char *config_file)
   if (rc != 0) {
       return rc;
   }
+  if (sf_file) {
+      /* a soundfont specified by mid_set_soundfont().
+       * skip config parsing. */
+      return 0;
+  }
   if (config_file == NULL || *config_file == '\0') {
       return init_with_config(TIMIDITY_CFG);
   }
   return init_with_config(config_file);
+}
+
+int Timidity_SetSoundfont(const char *file)
+{
+  if (file) {
+      char *fname = SDL_strdup(file);
+      if (!fname) return -1;
+      SDL_free(sf_file);
+      sf_file = fname;
+  }
+  return 0;
 }
 
 static void do_song_load(SDL_IOStream *io, SDL_AudioSpec *audio, MidiSong **out)

--- a/src/timidity/timidity.h
+++ b/src/timidity/timidity.h
@@ -25,6 +25,8 @@ typedef struct {
   Sint32
     loop_start, loop_end, data_length,
     sample_rate, low_freq, high_freq, root_freq;
+  Sint8
+    root_tune, fine_tune; /* for soundfont support */
   Sint32
     envelope_rate[6], envelope_offset[6];
   float
@@ -38,6 +40,8 @@ typedef struct {
     modes;
   Sint8
     panning, note_to_use;
+  Sint16
+    scale_tuning; /* for soundfont support */
 } Sample;
 
 typedef struct {
@@ -75,7 +79,11 @@ typedef struct {
 
 } Voice;
 
+#define INST_GUS        0
+#define INST_SF2        1
+
 typedef struct {
+  int type;
   int samples;
   Sample *sample;
 } Instrument;

--- a/src/timidity/timidity.h
+++ b/src/timidity/timidity.h
@@ -153,6 +153,9 @@ typedef struct {
 
 extern int Timidity_Init(const char *config_file);
 extern int Timidity_Init_NoConfig(void);
+/* Set the full path of a soundfont (sf2) to use. Must be called before Timidity_Init().
+ * If a soundfont is set, config file will not be parsed by Timidity_Init(). */
+extern int Timidity_SetSoundfont(const char *sf2_file);
 extern void Timidity_SetVolume(MidiSong *song, int volume);
 extern int Timidity_PlaySome(MidiSong *song, void *stream, Sint32 len);
 extern MidiSong *Timidity_LoadSong(SDL_IOStream *io, SDL_AudioSpec *audio);


### PR DESCRIPTION
This is port of the work that recently went into libtimidity:

- Soundfont support, based on a timidity-0.2i patch by Takashi Iwai
  dating from 1997. Note that more than one soundfont directives in
  the config file is not supported: Only the first encountered font
  in timidity.cfg will be used.

- SDL_sound decoder can reacts to a TIMIDITY_SOUNDFONT environment
  variable if available, signals embedded timidity to directly use
  the specified soundfont  and not parse timidity.cfg.

- Not ticking the template copyright checkbox: As noted above, almost
  all of the work is based on Takashi Iwai's old patch. In a private
  email to me, he agreed using his patch under Timidity dual license
  several years ago, because he follows the original licenses.
  And no, there is no AI involvement in this adaptation.

Please test and review.

P.S.: Posted an equivalent patchset to SDL_mixer, too: https://github.com/libsdl-org/SDL_mixer/pull/884



- [ ] I confirm that I am the author of this code and release it to the SDL_sound project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

